### PR TITLE
Add tarball package formats for Linux/MacOS

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
     "**/bin": true,
     "**/obj": true,
     "**/.vs": true
-  }
+  },
+  "powershell.codeFormatting.preset": "OTBS"
 }

--- a/build.ps1
+++ b/build.ps1
@@ -232,14 +232,14 @@ if (-not $SkipBuild) {
                 throw "Portable build failed for OpenDsc.Resources with exit code $LASTEXITCODE"
             }
 
-            Write-Host 'Creating portable ZIP archive for Linux...' -ForegroundColor Cyan
-            $zipDir = Join-Path $PSScriptRoot 'artifacts\zip'
-            New-Item -ItemType Directory -Path $zipDir -Force | Out-Null
-            $zipPath = Join-Path $zipDir "OpenDSC.Resources.Linux.Portable-$version.zip"
-            Compress-Archive -Path "$portableLinuxDir\*" -DestinationPath $zipPath -Force
+            Write-Host 'Creating portable tarball for Linux...' -ForegroundColor Cyan
+            $tarDir = Join-Path $PSScriptRoot 'artifacts\tar'
+            New-Item -ItemType Directory -Path $tarDir -Force | Out-Null
+            $tarPath = Join-Path $tarDir "OpenDSC.Resources.Linux.Portable-$version.tar.gz"
+            tar -czf $tarPath -C $portableLinuxDir .
             Write-Host 'Self-contained portable version for Linux built successfully!' -ForegroundColor Green
             Write-Host "Output location: $portableLinuxDir" -ForegroundColor Green
-            Write-Host "ZIP archive: $zipPath" -ForegroundColor Green
+            Write-Host "Tarball: $tarPath" -ForegroundColor Green
         }
     } elseif ($IsMacOS) {
         $resourcesProj = Join-Path $PSScriptRoot 'src\OpenDsc.Resources\OpenDsc.Resources.csproj'
@@ -261,17 +261,14 @@ if (-not $SkipBuild) {
         }
 
         if ($Portable) {
-            Write-Host 'Building self-contained portable version for macOS...' -ForegroundColor Cyan
+            Write-Host 'Building framework-dependent portable version for macOS...' -ForegroundColor Cyan
             $portableMacDir = Join-Path $PSScriptRoot 'artifacts\portable'
             New-Item -ItemType Directory -Path $portableMacDir -Force | Out-Null
             dotnet publish $resourcesProj `
                 --configuration $Configuration `
                 --runtime osx-arm64 `
-                --self-contained true `
+                --self-contained false `
                 -f net10.0 `
-                -p:PublishSingleFile=true `
-                -p:IncludeNativeLibrariesForSelfExtract=true `
-                -p:EnableCompressionInSingleFile=false `
                 -p:DebugType=None `
                 -p:DebugSymbols=false `
                 -p:GenerateDocumentationFile=false `
@@ -281,14 +278,14 @@ if (-not $SkipBuild) {
                 throw "Portable build failed for OpenDsc.Resources with exit code $LASTEXITCODE"
             }
 
-            Write-Host 'Creating portable ZIP archive for macOS...' -ForegroundColor Cyan
-            $zipDir = Join-Path $PSScriptRoot 'artifacts\zip'
-            New-Item -ItemType Directory -Path $zipDir -Force | Out-Null
-            $zipPath = Join-Path $zipDir "OpenDSC.Resources.macOS.Portable-$version.zip"
-            Compress-Archive -Path "$portableMacDir\*" -DestinationPath $zipPath -Force
-            Write-Host 'Self-contained portable version for macOS built successfully!' -ForegroundColor Green
+            Write-Host 'Creating portable tarball for macOS...' -ForegroundColor Cyan
+            $tarDir = Join-Path $PSScriptRoot 'artifacts\tar'
+            New-Item -ItemType Directory -Path $tarDir -Force | Out-Null
+            $tarPath = Join-Path $tarDir "OpenDSC.Resources.macOS.Portable-$version.tar.gz"
+            tar -czf $tarPath -C $portableMacDir .
+            Write-Host 'Framework-dependent portable version for macOS built successfully!' -ForegroundColor Green
             Write-Host "Output location: $portableMacDir" -ForegroundColor Green
-            Write-Host "ZIP archive: $zipPath" -ForegroundColor Green
+            Write-Host "Tarball: $tarPath" -ForegroundColor Green
         }
     }
 

--- a/build.ps1
+++ b/build.ps1
@@ -193,7 +193,7 @@ if (-not $SkipBuild) {
             }
         }
     } elseif ($IsLinux) {
-        $resourcesProj = Join-Path $PSScriptRoot 'src\OpenDsc.Resources\OpenDsc.Resources.csproj'
+        $resourcesProj = Join-Path $PSScriptRoot 'src' 'OpenDsc.Resources' 'OpenDsc.Resources.csproj'
         if (Test-Path $resourcesProj) {
             dotnet publish $resourcesProj -c $Configuration -f net10.0 -o $publishDir -p:GenerateDocumentationFile=false
             if ($LASTEXITCODE -ne 0) {
@@ -202,9 +202,9 @@ if (-not $SkipBuild) {
         }
 
         Write-Host 'Building LCM Service for Linux...' -ForegroundColor Cyan
-        $lcmProj = Join-Path $PSScriptRoot 'src\OpenDsc.Lcm\OpenDsc.Lcm.csproj'
+        $lcmProj = Join-Path $PSScriptRoot 'src' 'OpenDsc.Lcm' 'OpenDsc.Lcm.csproj'
         if (Test-Path $lcmProj) {
-            $lcmDir = Join-Path $PSScriptRoot 'artifacts\Lcm'
+            $lcmDir = Join-Path $PSScriptRoot 'artifacts' 'Lcm'
             dotnet publish $lcmProj -c $Configuration -f net10.0 -o $lcmDir -p:GenerateDocumentationFile=false
             if ($LASTEXITCODE -ne 0) {
                 throw "Build failed for OpenDsc.Lcm with exit code $LASTEXITCODE"
@@ -213,7 +213,7 @@ if (-not $SkipBuild) {
 
         if ($Portable) {
             Write-Host 'Building self-contained portable version for Linux...' -ForegroundColor Cyan
-            $portableLinuxDir = Join-Path $PSScriptRoot 'artifacts\portable'
+            $portableLinuxDir = Join-Path $PSScriptRoot 'artifacts' 'portable'
             New-Item -ItemType Directory -Path $portableLinuxDir -Force | Out-Null
             dotnet publish $resourcesProj `
                 --configuration $Configuration `
@@ -233,16 +233,19 @@ if (-not $SkipBuild) {
             }
 
             Write-Host 'Creating portable tarball for Linux...' -ForegroundColor Cyan
-            $tarDir = Join-Path $PSScriptRoot 'artifacts\tar'
+            $tarDir = Join-Path $PSScriptRoot 'artifacts' 'tar'
             New-Item -ItemType Directory -Path $tarDir -Force | Out-Null
             $tarPath = Join-Path $tarDir "OpenDSC.Resources.Linux.Portable-$version.tar.gz"
             tar -czf $tarPath -C $portableLinuxDir .
+            if ($LASTEXITCODE -ne 0) {
+                throw "Portable tarball creation failed for macOS with exit code $LASTEXITCODE"
+            }
             Write-Host 'Self-contained portable version for Linux built successfully!' -ForegroundColor Green
             Write-Host "Output location: $portableLinuxDir" -ForegroundColor Green
             Write-Host "Tarball: $tarPath" -ForegroundColor Green
         }
     } elseif ($IsMacOS) {
-        $resourcesProj = Join-Path $PSScriptRoot 'src\OpenDsc.Resources\OpenDsc.Resources.csproj'
+        $resourcesProj = Join-Path $PSScriptRoot 'src' 'OpenDsc.Resources' 'OpenDsc.Resources.csproj'
         if (Test-Path $resourcesProj) {
             dotnet publish $resourcesProj -c $Configuration -f net10.0 -o $publishDir -p:GenerateDocumentationFile=false
             if ($LASTEXITCODE -ne 0) {
@@ -251,9 +254,9 @@ if (-not $SkipBuild) {
         }
 
         Write-Host 'Building LCM Service for macOS...' -ForegroundColor Cyan
-        $lcmProj = Join-Path $PSScriptRoot 'src\OpenDsc.Lcm\OpenDsc.Lcm.csproj'
+        $lcmProj = Join-Path $PSScriptRoot 'src' 'OpenDsc.Lcm' 'OpenDsc.Lcm.csproj'
         if (Test-Path $lcmProj) {
-            $lcmDir = Join-Path $PSScriptRoot 'artifacts\Lcm'
+            $lcmDir = Join-Path $PSScriptRoot 'artifacts' 'Lcm'
             dotnet publish $lcmProj -c $Configuration -f net10.0 -o $lcmDir -p:GenerateDocumentationFile=false
             if ($LASTEXITCODE -ne 0) {
                 throw "Build failed for OpenDsc.Lcm with exit code $LASTEXITCODE"
@@ -262,7 +265,7 @@ if (-not $SkipBuild) {
 
         if ($Portable) {
             Write-Host 'Building framework-dependent portable version for macOS...' -ForegroundColor Cyan
-            $portableMacDir = Join-Path $PSScriptRoot 'artifacts\portable'
+            $portableMacDir = Join-Path $PSScriptRoot 'artifacts' 'portable'
             New-Item -ItemType Directory -Path $portableMacDir -Force | Out-Null
             dotnet publish $resourcesProj `
                 --configuration $Configuration `
@@ -279,10 +282,13 @@ if (-not $SkipBuild) {
             }
 
             Write-Host 'Creating portable tarball for macOS...' -ForegroundColor Cyan
-            $tarDir = Join-Path $PSScriptRoot 'artifacts\tar'
+            $tarDir = Join-Path $PSScriptRoot 'artifacts' 'tar'
             New-Item -ItemType Directory -Path $tarDir -Force | Out-Null
             $tarPath = Join-Path $tarDir "OpenDSC.Resources.macOS.Portable-$version.tar.gz"
             tar -czf $tarPath -C $portableMacDir .
+            if ($LASTEXITCODE -ne 0) {
+                throw "Portable tarball creation failed for macOS with exit code $LASTEXITCODE"
+            }
             Write-Host 'Framework-dependent portable version for macOS built successfully!' -ForegroundColor Green
             Write-Host "Output location: $portableMacDir" -ForegroundColor Green
             Write-Host "Tarball: $tarPath" -ForegroundColor Green
@@ -290,7 +296,7 @@ if (-not $SkipBuild) {
     }
 
     if ($Pack) {
-        $packagesDir = Join-Path $PSScriptRoot 'artifacts\packages'
+        $packagesDir = Join-Path $PSScriptRoot 'artifacts' 'packages'
         New-Item -ItemType Directory -Path $packagesDir -Force | Out-Null
         dotnet pack $PSScriptRoot --configuration $Configuration --output $packagesDir
         if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
Adds tarball package formats for package management tools (Linux/MacOS0. 

Fix #39 and #40.

(Added Powershell rule formatter as it was messing with my local settings).