### PR TITLE
Initial MCP server for OpenDsc.Server

### DIFF
--- a/.github/agents/csharp-mcp-expert.agent.md
+++ b/.github/agents/csharp-mcp-expert.agent.md
@@ -1,0 +1,110 @@
+---
+description: "Expert assistant for developing Model Context Protocol (MCP) servers in C#"
+name: "C# MCP Server Expert"
+model: Claude Opus 4.6 (copilot)
+---
+
+# C# MCP Server Expert
+
+You are a world-class expert in building Model Context Protocol (MCP) servers using the C# SDK. You have deep knowledge of the ModelContextProtocol NuGet packages, .NET dependency injection, async programming, and best practices for building robust, production-ready MCP servers.
+
+## Your Expertise
+
+- **C# MCP SDK**: Complete mastery of ModelContextProtocol, ModelContextProtocol.AspNetCore, and ModelContextProtocol.Core packages
+- **.NET Architecture**: Expert in Microsoft.Extensions.Hosting, dependency injection, and service lifetime management
+- **MCP Protocol**: Deep understanding of the Model Context Protocol specification, client-server communication, and tool/prompt/resource patterns
+- **Async Programming**: Expert in async/await patterns, cancellation tokens, and proper async error handling
+- **Tool Design**: Creating intuitive, well-documented tools that LLMs can effectively use
+- **Prompt Design**: Building reusable prompt templates that return structured `ChatMessage` responses
+- **Resource Design**: Exposing static and dynamic content through URI-based resources
+- **Best Practices**: Security, error handling, logging, testing, and maintainability
+- **Debugging**: Troubleshooting stdio transport issues, serialization problems, and protocol errors
+
+## Your Approach
+
+- **Start with Context**: Always understand the user's goal and what their MCP server needs to accomplish
+- **Follow Best Practices**: Use proper attributes (`[McpServerToolType]`, `[McpServerTool]`, `[McpServerPromptType]`, `[McpServerPrompt]`, `[McpServerResourceType]`, `[McpServerResource]`, `[Description]`), configure logging to stderr, and implement comprehensive error handling
+- **Write Clean Code**: Follow C# conventions, use nullable reference types, include XML documentation, and organize code logically
+- **Dependency Injection First**: Leverage DI for services, use parameter injection in tool methods, and manage service lifetimes properly
+- **Test-Driven Mindset**: Consider how tools will be tested and provide testing guidance
+- **Security Conscious**: Always consider security implications of tools that access files, networks, or system resources
+- **LLM-Friendly**: Write descriptions that help LLMs understand when and how to use tools effectively
+
+## Guidelines
+
+### General
+
+- Always use prerelease NuGet packages with `--prerelease` flag
+- Configure logging to stderr using `LogToStandardErrorThreshold = LogLevel.Trace`
+- Use `Host.CreateApplicationBuilder` for proper DI and lifecycle management
+- Add `[Description]` attributes to all tools, prompts, resources and their parameters for LLM understanding
+- Support async operations with proper `CancellationToken` usage
+- Use `McpProtocolException` with appropriate `McpErrorCode` for protocol errors
+- Validate input parameters and provide clear error messages
+- Provide complete, runnable code examples that users can immediately use
+- Include comments explaining complex logic or protocol-specific patterns
+- Consider performance implications of operations
+- Think about error scenarios and handle them gracefully
+
+### Tools Best Practices
+
+- Use `[McpServerToolType]` on classes containing related tools
+- Use `[McpServerTool(Name = "tool_name")]` with snake_case naming convention
+- Organize related tools into classes (e.g., `ComponentListTools`, `ComponentDetailTools`)
+- Return simple types (`string`) or JSON-serializable objects from tools
+- Use `McpServer.AsSamplingChatClient()` when tools need to interact with the client's LLM
+- Format output as Markdown for better readability by LLMs
+- Include usage hints in output (e.g., "Use GetComponentDetails(componentName) for more information")
+
+### Prompts Best Practices
+
+- Use `[McpServerPromptType]` on classes containing related prompts
+- Use `[McpServerPrompt(Name = "prompt_name")]` with snake_case naming convention
+- **One prompt class per prompt** for better organization and maintainability
+- Return `ChatMessage` from prompt methods (not string) for proper MCP protocol compliance
+- Use `ChatRole.User` for prompts that represent user instructions
+- Include comprehensive context in the prompt content (component details, examples, guidelines)
+- Use `[Description]` to explain what the prompt generates and when to use it
+- Accept optional parameters with default values for flexible prompt customization
+- Build prompt content using `StringBuilder` for complex multi-section prompts
+- Include code examples and best practices directly in prompt content
+
+### Resources Best Practices
+
+- Use `[McpServerResourceType]` on classes containing related resources
+- Use `[McpServerResource]` with these key properties:
+  - `UriTemplate`: URI pattern with optional parameters (e.g., `"myapp://component/{name}"`)
+  - `Name`: Unique identifier for the resource
+  - `Title`: Human-readable title
+  - `MimeType`: Content type (typically `"text/markdown"` or `"application/json"`)
+- Group related resources in the same class (e.g., `GuideResources`, `ComponentResources`)
+- Use URI templates with parameters for dynamic resources: `"projectname://component/{name}"`
+- Use static URIs for fixed resources: `"projectname://guides"`
+- Return formatted Markdown content for documentation resources
+- Include navigation hints and links to related resources
+- Handle missing resources gracefully with helpful error messages
+
+## Common Scenarios You Excel At
+
+- **Creating New Servers**: Generating complete project structures with proper configuration
+- **Tool Development**: Implementing tools for file operations, HTTP requests, data processing, or system interactions
+- **Prompt Implementation**: Creating reusable prompt templates with `[McpServerPrompt]` that return `ChatMessage`
+- **Resource Implementation**: Exposing static and dynamic content through URI-based `[McpServerResource]`
+- **Debugging**: Helping diagnose stdio transport issues, serialization errors, or protocol problems
+- **Refactoring**: Improving existing MCP servers for better maintainability, performance, or functionality
+- **Integration**: Connecting MCP servers with databases, APIs, or other services via DI
+- **Testing**: Writing unit tests for tools, prompts, and resources
+- **Optimization**: Improving performance, reducing memory usage, or enhancing error handling
+
+## Response Style
+
+- Provide complete, working code examples that can be copied and used immediately
+- Include necessary using statements and namespace declarations
+- Add inline comments for complex or non-obvious code
+- Explain the "why" behind design decisions
+- Highlight potential pitfalls or common mistakes to avoid
+- Suggest improvements or alternative approaches when relevant
+- Include troubleshooting tips for common issues
+- Format code clearly with proper indentation and spacing
+
+You help developers build high-quality MCP servers that are robust, maintainable, secure, and easy for LLMs to use effectively.

--- a/.github/skills/csharp-mcp-server-generator/SKILL.md
+++ b/.github/skills/csharp-mcp-server-generator/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: csharp-mcp-server-generator
+description: "Generate a complete MCP server project in C# with tools, prompts, and proper configuration"
+---
+
+# Generate C# MCP Server
+
+Create a complete Model Context Protocol (MCP) server in C# with the following specifications:
+
+## Requirements
+
+1. **Project Structure**: Create a new C# console application with proper directory structure
+2. **NuGet Packages**: Include ModelContextProtocol (prerelease) and Microsoft.Extensions.Hosting
+3. **Logging Configuration**: Configure all logs to stderr to avoid interfering with stdio transport
+4. **Server Setup**: Use the Host builder pattern with proper DI configuration
+5. **Tools**: Create at least one useful tool with proper attributes and descriptions
+6. **Error Handling**: Include proper error handling and validation
+
+## Implementation Details
+
+### Basic Project Setup
+
+- Use .NET 8.0 or later
+- Create a console application
+- Add necessary NuGet packages with --prerelease flag
+- Configure logging to stderr
+
+### Server Configuration
+
+- Use `Host.CreateApplicationBuilder` for DI and lifecycle management
+- Configure `AddMcpServer()` with stdio transport
+- Use `WithToolsFromAssembly()` for automatic tool discovery
+- Ensure the server runs with `RunAsync()`
+
+### Tool Implementation
+
+- Use `[McpServerToolType]` attribute on tool classes
+- Use `[McpServerTool]` attribute on tool methods
+- Add `[Description]` attributes to tools and parameters
+- Support async operations where appropriate
+- Include proper parameter validation
+
+### Code Quality
+
+- Follow C# naming conventions
+- Include XML documentation comments
+- Use nullable reference types
+- Implement proper error handling with McpProtocolException
+- Use structured logging for debugging
+
+## Example Tool Types to Consider
+
+- File operations (read, write, search)
+- Data processing (transform, validate, analyze)
+- External API integrations (HTTP requests)
+- System operations (execute commands, check status)
+- Database operations (query, update)
+
+## Testing Guidance
+
+- Explain how to run the server
+- Provide example commands to test with MCP clients
+- Include troubleshooting tips
+
+Generate a complete, production-ready MCP server with comprehensive documentation and error handling.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,8 +23,7 @@
     <PackageVersion Include="WixToolset.Util.wixext" Version="6.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables"
-      Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageVersion Include="Microsoft.SqlServer.SqlManagementObjects" Version="180.10.0" />
@@ -49,6 +48,7 @@
     <PackageVersion Include="Testcontainers.MsSql" Version="3.10.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="3.10.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.0" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
     <PackageVersion Include="MudBlazor" Version="8.1.0" />
     <PackageVersion Include="BlazorMonaco" Version="3.4.0" />
   </ItemGroup>

--- a/src/OpenDsc.Server/Mcp/AnalysisPrompts.cs
+++ b/src/OpenDsc.Server/Mcp/AnalysisPrompts.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Thomas Nieto - All Rights Reserved
+// You may use, distribute and modify this code under the
+// terms of the MIT license.
+
+using System.ComponentModel;
+
+using Microsoft.Extensions.AI;
+
+using ModelContextProtocol.Server;
+
+namespace OpenDsc.Server.Mcp;
+
+[McpServerPromptType]
+public sealed class AnalysisPrompts
+{
+    [McpServerPrompt(Name = "analyze_fleet_health"), Description("Generate a prompt to analyze the overall health and compliance posture of the managed node fleet.")]
+    public static ChatMessage AnalyzeFleetHealth()
+    {
+        return new ChatMessage(
+            ChatRole.User,
+            """
+            Analyze the health and compliance posture of the managed node fleet.
+
+            Follow these steps:
+            1. Call `get_compliance_summary` to get an overview of node statuses.
+            2. If there are any non-compliant or error nodes, call `get_non_compliant_nodes` to list them.
+            3. Call `get_stale_nodes` to check for nodes that are not checking in on schedule.
+            4. Call `get_unassigned_nodes` to find any nodes without a configuration.
+            5. Call `get_failed_reports` to review recent compliance failures.
+
+            Summarize findings as a health report with:
+            - Overall fleet status (healthy, degraded, critical)
+            - Key metrics (total nodes, compliant %, non-compliant count, stale count)
+            - Top issues requiring attention
+            - Recommended actions
+            """);
+    }
+
+    [McpServerPrompt(Name = "investigate_node"), Description("Generate a prompt to investigate a specific node's compliance issues.")]
+    public static ChatMessage InvestigateNode(
+        [Description("The FQDN of the node to investigate.")] string nodeFqdn)
+    {
+        return new ChatMessage(
+            ChatRole.User,
+            $"""
+            Investigate the compliance status of node `{nodeFqdn}`.
+
+            Follow these steps:
+            1. Call `get_node_details` with FQDN `{nodeFqdn}` to get the node's current state.
+            2. Call `get_node_reports` with FQDN `{nodeFqdn}` to review its recent compliance history.
+            3. If the node has a configuration assigned, call `get_configuration_details` with the configuration name.
+
+            Summarize findings with:
+            - Current node status and whether it is stale
+            - Recent compliance trend (improving, stable, degrading)
+            - Any errors or non-compliant reports
+            - Recommended next steps
+            """);
+    }
+}

--- a/src/OpenDsc.Server/Mcp/ConfigurationTools.cs
+++ b/src/OpenDsc.Server/Mcp/ConfigurationTools.cs
@@ -9,18 +9,32 @@ using Microsoft.EntityFrameworkCore;
 
 using ModelContextProtocol.Server;
 
+using OpenDsc.Server.Authorization;
 using OpenDsc.Server.Data;
+using OpenDsc.Server.Services;
 
 namespace OpenDsc.Server.Mcp;
 
 [McpServerToolType]
-public sealed class ConfigurationTools(ServerDbContext db)
+public sealed class ConfigurationTools(
+    ServerDbContext db,
+    IUserContextService userContext,
+    IResourceAuthorizationService authService)
 {
     [McpServerTool(Name = "list_configurations"), Description("List all available DSC configurations with their assigned node counts and version counts.")]
     public async Task<string> ListConfigurations(CancellationToken cancellationToken)
     {
+        var userId = userContext.GetCurrentUserId();
+        if (userId == null)
+        {
+            return "No configurations found.";
+        }
+
+        var readableIds = await authService.GetReadableConfigurationIdsAsync(userId.Value);
+
         var configs = await db.Configurations
             .AsNoTracking()
+            .Where(c => readableIds.Contains(c.Id))
             .Select(c => new
             {
                 c.Id,
@@ -62,9 +76,7 @@ public sealed class ConfigurationTools(ServerDbContext db)
         CancellationToken cancellationToken)
     {
         IQueryable<Entities.Configuration> query = db.Configurations
-            .AsNoTracking()
-            .Include(c => c.Versions)
-            .Include(c => c.NodeConfigurations);
+            .AsNoTracking();
 
         if (Guid.TryParse(configIdentifier, out var configId))
         {
@@ -82,16 +94,24 @@ public sealed class ConfigurationTools(ServerDbContext db)
             return $"Configuration `{configIdentifier}` not found.";
         }
 
+        var userId = userContext.GetCurrentUserId();
+        if (userId == null || !await authService.CanReadConfigurationAsync(userId.Value, config.Id))
+        {
+            return $"Configuration `{configIdentifier}` not found.";
+        }
+
         var assignedNodes = await db.NodeConfigurations
             .AsNoTracking()
             .Where(nc => nc.ConfigurationId == config.Id)
             .Join(db.Nodes.AsNoTracking(), nc => nc.NodeId, n => n.Id, (nc, n) => new { n.Fqdn, n.Status, nc.ActiveVersion })
             .ToListAsync(cancellationToken);
 
-        var versions = config.Versions
+        var versions = await db.ConfigurationVersions
+            .AsNoTracking()
+            .Where(v => v.ConfigurationId == config.Id)
             .OrderByDescending(v => v.CreatedAt)
             .Take(5)
-            .ToList();
+            .ToListAsync(cancellationToken);
 
         var sb = new StringBuilder();
         sb.AppendLine($"## Configuration: {config.Name}");
@@ -147,6 +167,11 @@ public sealed class ConfigurationTools(ServerDbContext db)
     [McpServerTool(Name = "get_unassigned_nodes"), Description("Get nodes that do not have a configuration assigned. These nodes are not being managed.")]
     public async Task<string> GetUnassignedNodes(CancellationToken cancellationToken)
     {
+        if (!userContext.HasPermission(Permissions.Nodes_Read))
+        {
+            return "Access denied. You need the `nodes.read` permission.";
+        }
+
         var nodes = await db.Nodes
             .AsNoTracking()
             .Where(n => n.ConfigurationName == null)

--- a/src/OpenDsc.Server/Mcp/ConfigurationTools.cs
+++ b/src/OpenDsc.Server/Mcp/ConfigurationTools.cs
@@ -1,0 +1,178 @@
+// Copyright (c) Thomas Nieto - All Rights Reserved
+// You may use, distribute and modify this code under the
+// terms of the MIT license.
+
+using System.ComponentModel;
+using System.Text;
+
+using Microsoft.EntityFrameworkCore;
+
+using ModelContextProtocol.Server;
+
+using OpenDsc.Server.Data;
+
+namespace OpenDsc.Server.Mcp;
+
+[McpServerToolType]
+public sealed class ConfigurationTools(ServerDbContext db)
+{
+    [McpServerTool(Name = "list_configurations"), Description("List all available DSC configurations with their assigned node counts and version counts.")]
+    public async Task<string> ListConfigurations(CancellationToken cancellationToken)
+    {
+        var configs = await db.Configurations
+            .AsNoTracking()
+            .Select(c => new
+            {
+                c.Id,
+                c.Name,
+                c.Description,
+                NodeCount = c.NodeConfigurations.Count,
+                VersionCount = c.Versions.Count,
+                c.CreatedAt,
+                c.UpdatedAt
+            })
+            .OrderBy(c => c.Name)
+            .ToListAsync(cancellationToken);
+
+        if (configs.Count == 0)
+        {
+            return "No configurations found.";
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"## Configurations ({configs.Count})");
+        sb.AppendLine();
+        sb.AppendLine("| Name | Nodes | Versions | Description |");
+        sb.AppendLine("|------|-------|----------|-------------|");
+
+        foreach (var c in configs)
+        {
+            sb.AppendLine($"| {c.Name} | {c.NodeCount} | {c.VersionCount} | {c.Description ?? "—"} |");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("**Hint:** Use `get_configuration_details` with a configuration name for full details including assigned nodes and versions.");
+
+        return sb.ToString();
+    }
+
+    [McpServerTool(Name = "get_configuration_details"), Description("Get detailed information about a specific configuration including its versions and assigned nodes.")]
+    public async Task<string> GetConfigurationDetails(
+        [Description("The configuration name or GUID identifier.")] string configIdentifier,
+        CancellationToken cancellationToken)
+    {
+        IQueryable<Entities.Configuration> query = db.Configurations
+            .AsNoTracking()
+            .Include(c => c.Versions)
+            .Include(c => c.NodeConfigurations);
+
+        if (Guid.TryParse(configIdentifier, out var configId))
+        {
+            query = query.Where(c => c.Id == configId);
+        }
+        else
+        {
+            query = query.Where(c => c.Name == configIdentifier);
+        }
+
+        var config = await query.FirstOrDefaultAsync(cancellationToken);
+
+        if (config is null)
+        {
+            return $"Configuration `{configIdentifier}` not found.";
+        }
+
+        var assignedNodes = await db.NodeConfigurations
+            .AsNoTracking()
+            .Where(nc => nc.ConfigurationId == config.Id)
+            .Join(db.Nodes.AsNoTracking(), nc => nc.NodeId, n => n.Id, (nc, n) => new { n.Fqdn, n.Status, nc.ActiveVersion })
+            .ToListAsync(cancellationToken);
+
+        var versions = config.Versions
+            .OrderByDescending(v => v.CreatedAt)
+            .Take(5)
+            .ToList();
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"## Configuration: {config.Name}");
+        sb.AppendLine();
+        sb.AppendLine("| Property | Value |");
+        sb.AppendLine("|----------|-------|");
+        sb.AppendLine($"| **ID** | `{config.Id}` |");
+        sb.AppendLine($"| **Description** | {config.Description ?? "—"} |");
+        sb.AppendLine($"| **Server-Managed Parameters** | {config.UseServerManagedParameters} |");
+        sb.AppendLine($"| **Created** | {config.CreatedAt:u} |");
+        sb.AppendLine($"| **Updated** | {config.UpdatedAt?.ToString("u") ?? "—"} |");
+        sb.AppendLine();
+
+        sb.AppendLine($"### Assigned Nodes ({assignedNodes.Count})");
+        sb.AppendLine();
+        if (assignedNodes.Count > 0)
+        {
+            sb.AppendLine("| FQDN | Status | Version |");
+            sb.AppendLine("|------|--------|---------|");
+            foreach (var n in assignedNodes)
+            {
+                sb.AppendLine($"| {n.Fqdn} | **{n.Status}** | {n.ActiveVersion ?? "—"} |");
+            }
+        }
+        else
+        {
+            sb.AppendLine("No nodes assigned to this configuration.");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"### Recent Versions (up to 5)");
+        sb.AppendLine();
+        if (versions.Count > 0)
+        {
+            sb.AppendLine("| Version | Created |");
+            sb.AppendLine("|---------|---------|");
+            foreach (var v in versions)
+            {
+                sb.AppendLine($"| {v.Version} | {v.CreatedAt:u} |");
+            }
+        }
+        else
+        {
+            sb.AppendLine("No versions published yet.");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("**Hint:** Use `get_node_details` with a node's FQDN to see its full status.");
+
+        return sb.ToString();
+    }
+
+    [McpServerTool(Name = "get_unassigned_nodes"), Description("Get nodes that do not have a configuration assigned. These nodes are not being managed.")]
+    public async Task<string> GetUnassignedNodes(CancellationToken cancellationToken)
+    {
+        var nodes = await db.Nodes
+            .AsNoTracking()
+            .Where(n => n.ConfigurationName == null)
+            .OrderBy(n => n.Fqdn)
+            .Select(n => new { n.Id, n.Fqdn, n.Status, n.LastCheckIn })
+            .ToListAsync(cancellationToken);
+
+        if (nodes.Count == 0)
+        {
+            return "All nodes have a configuration assigned.";
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"## Unassigned Nodes ({nodes.Count})");
+        sb.AppendLine();
+        sb.AppendLine("| FQDN | Status | Last Check-In |");
+        sb.AppendLine("|------|--------|---------------|");
+
+        foreach (var n in nodes)
+        {
+            sb.AppendLine($"| {n.Fqdn} | {n.Status} | {n.LastCheckIn?.ToString("u") ?? "never"} |");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("**Hint:** Use `list_configurations` to see available configurations that can be assigned to these nodes.");
+
+        return sb.ToString();
+    }
+}

--- a/src/OpenDsc.Server/Mcp/NodeTools.cs
+++ b/src/OpenDsc.Server/Mcp/NodeTools.cs
@@ -1,0 +1,213 @@
+// Copyright (c) Thomas Nieto - All Rights Reserved
+// You may use, distribute and modify this code under the
+// terms of the MIT license.
+
+using System.ComponentModel;
+using System.Text;
+
+using Microsoft.EntityFrameworkCore;
+
+using ModelContextProtocol.Server;
+
+using OpenDsc.Server.Data;
+using OpenDsc.Server.Entities;
+
+namespace OpenDsc.Server.Mcp;
+
+[McpServerToolType]
+public sealed class NodeTools(ServerDbContext db)
+{
+    [McpServerTool(Name = "get_non_compliant_nodes"), Description("Get a list of nodes that are not in compliance. Returns nodes with NonCompliant or Error status.")]
+    public async Task<string> GetNonCompliantNodes(CancellationToken cancellationToken)
+    {
+        var nodes = await db.Nodes
+            .AsNoTracking()
+            .Where(n => n.Status == NodeStatus.NonCompliant || n.Status == NodeStatus.Error)
+            .OrderBy(n => n.Fqdn)
+            .Select(n => new { n.Id, n.Fqdn, n.ConfigurationName, Status = n.Status.ToString(), n.LastCheckIn })
+            .ToListAsync(cancellationToken);
+
+        if (nodes.Count == 0)
+        {
+            return "All nodes are compliant. No non-compliant or error nodes found.";
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"## Non-Compliant Nodes ({nodes.Count})");
+        sb.AppendLine();
+        sb.AppendLine("| FQDN | Status | Configuration | Last Check-In |");
+        sb.AppendLine("|------|--------|---------------|---------------|");
+
+        foreach (var n in nodes)
+        {
+            sb.AppendLine($"| {n.Fqdn} | **{n.Status}** | {n.ConfigurationName ?? "—"} | {n.LastCheckIn?.ToString("u") ?? "never"} |");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("**Hint:** Use `get_node_details` with a node's FQDN for full details, or `get_node_reports` for its compliance history.");
+
+        return sb.ToString();
+    }
+
+    [McpServerTool(Name = "get_nodes_by_status"), Description("Get nodes filtered by compliance status. Valid statuses: Unknown, Compliant, NonCompliant, Error.")]
+    public async Task<string> GetNodesByStatus(
+        [Description("The compliance status to filter by (Unknown, Compliant, NonCompliant, Error).")] string status,
+        CancellationToken cancellationToken)
+    {
+        if (!Enum.TryParse<NodeStatus>(status, ignoreCase: true, out var nodeStatus))
+        {
+            return $"Invalid status `{status}`. Valid values are: `Unknown`, `Compliant`, `NonCompliant`, `Error`.";
+        }
+
+        var nodes = await db.Nodes
+            .AsNoTracking()
+            .Where(n => n.Status == nodeStatus)
+            .OrderBy(n => n.Fqdn)
+            .Select(n => new { n.Id, n.Fqdn, n.ConfigurationName, n.LastCheckIn })
+            .ToListAsync(cancellationToken);
+
+        if (nodes.Count == 0)
+        {
+            return $"No nodes found with status **{nodeStatus}**.";
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"## Nodes with Status: {nodeStatus} ({nodes.Count})");
+        sb.AppendLine();
+        sb.AppendLine("| FQDN | Configuration | Last Check-In |");
+        sb.AppendLine("|------|---------------|---------------|");
+
+        foreach (var n in nodes)
+        {
+            sb.AppendLine($"| {n.Fqdn} | {n.ConfigurationName ?? "—"} | {n.LastCheckIn?.ToString("u") ?? "never"} |");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("**Hint:** Use `get_node_details` with a node's FQDN for full details.");
+
+        return sb.ToString();
+    }
+
+    [McpServerTool(Name = "get_node_details"), Description("Get detailed information about a specific node by its FQDN or ID. Includes compliance status, LCM status, configuration, staleness, and certificate info.")]
+    public async Task<string> GetNodeDetails(
+        [Description("The node's fully qualified domain name or GUID identifier.")] string nodeIdentifier,
+        CancellationToken cancellationToken)
+    {
+        var settings = await db.ServerSettings.AsNoTracking().FirstOrDefaultAsync(cancellationToken);
+        var staleness = settings?.StalenessMultiplier ?? 2.0;
+        var now = DateTimeOffset.UtcNow;
+
+        Node? node;
+        if (Guid.TryParse(nodeIdentifier, out var nodeId))
+        {
+            node = await db.Nodes.AsNoTracking().FirstOrDefaultAsync(n => n.Id == nodeId, cancellationToken);
+        }
+        else
+        {
+            node = await db.Nodes.AsNoTracking().FirstOrDefaultAsync(n => n.Fqdn == nodeIdentifier, cancellationToken);
+        }
+
+        if (node is null)
+        {
+            return $"Node `{nodeIdentifier}` not found.";
+        }
+
+        var isStale = node.LastCheckIn.HasValue
+            && node.ConfigurationModeInterval.HasValue
+            && (now - node.LastCheckIn.Value) > node.ConfigurationModeInterval.Value * staleness;
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"## Node: {node.Fqdn}");
+        sb.AppendLine();
+        sb.AppendLine("| Property | Value |");
+        sb.AppendLine("|----------|-------|");
+        sb.AppendLine($"| **ID** | `{node.Id}` |");
+        sb.AppendLine($"| **Status** | **{node.Status}** |");
+        sb.AppendLine($"| **LCM Status** | {node.LcmStatus} |");
+        sb.AppendLine($"| **Configuration** | {node.ConfigurationName ?? "—"} |");
+        sb.AppendLine($"| **Configuration Source** | {node.ConfigurationSource} |");
+        sb.AppendLine($"| **Configuration Mode** | {node.ConfigurationMode?.ToString() ?? "—"} |");
+        sb.AppendLine($"| **Configuration Interval** | {node.ConfigurationModeInterval?.ToString() ?? "—"} |");
+        sb.AppendLine($"| **Report Compliance** | {node.ReportCompliance?.ToString() ?? "—"} |");
+        sb.AppendLine($"| **Is Stale** | {isStale} |");
+        sb.AppendLine($"| **Last Check-In** | {node.LastCheckIn?.ToString("u") ?? "never"} |");
+        sb.AppendLine($"| **Registered** | {node.CreatedAt:u} |");
+        sb.AppendLine($"| **Certificate Expires** | {node.CertificateNotAfter:u} |");
+        sb.AppendLine();
+        sb.AppendLine("**Hint:** Use `get_node_reports` to see this node's compliance report history.");
+
+        return sb.ToString();
+    }
+
+    [McpServerTool(Name = "get_stale_nodes"), Description("Get nodes that have not checked in within the expected interval (stale nodes). A node is stale when its last check-in exceeds ConfigurationModeInterval multiplied by the staleness multiplier.")]
+    public async Task<string> GetStaleNodes(CancellationToken cancellationToken)
+    {
+        var settings = await db.ServerSettings.AsNoTracking().FirstOrDefaultAsync(cancellationToken);
+        var staleness = settings?.StalenessMultiplier ?? 2.0;
+        var now = DateTimeOffset.UtcNow;
+
+        var nodes = await db.Nodes.AsNoTracking().ToListAsync(cancellationToken);
+
+        var staleNodes = nodes
+            .Where(n => n.LastCheckIn.HasValue
+                && n.ConfigurationModeInterval.HasValue
+                && (now - n.LastCheckIn.Value) > n.ConfigurationModeInterval.Value * staleness)
+            .OrderBy(n => n.LastCheckIn)
+            .ToList();
+
+        if (staleNodes.Count == 0)
+        {
+            return "No stale nodes found. All nodes are checking in on schedule.";
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"## Stale Nodes ({staleNodes.Count})");
+        sb.AppendLine();
+        sb.AppendLine("| FQDN | Status | Last Check-In |");
+        sb.AppendLine("|------|--------|---------------|");
+
+        foreach (var n in staleNodes)
+        {
+            sb.AppendLine($"| {n.Fqdn} | **{n.Status}** | {n.LastCheckIn?.ToString("u") ?? "never"} |");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("**Hint:** Use `get_node_details` with a node's FQDN to investigate further.");
+
+        return sb.ToString();
+    }
+
+    [McpServerTool(Name = "get_compliance_summary"), Description("Get an overall compliance summary showing the count of nodes in each status category. Use this as a starting point to understand the fleet's health.")]
+    public async Task<string> GetComplianceSummary(CancellationToken cancellationToken)
+    {
+        var settings = await db.ServerSettings.AsNoTracking().FirstOrDefaultAsync(cancellationToken);
+        var staleness = settings?.StalenessMultiplier ?? 2.0;
+        var now = DateTimeOffset.UtcNow;
+
+        var nodes = await db.Nodes.AsNoTracking().ToListAsync(cancellationToken);
+
+        var statusGroups = nodes
+            .GroupBy(n => n.Status)
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        var staleCount = nodes.Count(n =>
+            n.LastCheckIn.HasValue
+            && n.ConfigurationModeInterval.HasValue
+            && (now - n.LastCheckIn.Value) > n.ConfigurationModeInterval.Value * staleness);
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"## Compliance Summary ({nodes.Count} total nodes)");
+        sb.AppendLine();
+        sb.AppendLine("| Status | Count |");
+        sb.AppendLine("|--------|-------|");
+        sb.AppendLine($"| Compliant | {statusGroups.GetValueOrDefault(NodeStatus.Compliant)} |");
+        sb.AppendLine($"| Non-Compliant | {statusGroups.GetValueOrDefault(NodeStatus.NonCompliant)} |");
+        sb.AppendLine($"| Error | {statusGroups.GetValueOrDefault(NodeStatus.Error)} |");
+        sb.AppendLine($"| Unknown | {statusGroups.GetValueOrDefault(NodeStatus.Unknown)} |");
+        sb.AppendLine($"| Stale | {staleCount} |");
+        sb.AppendLine();
+        sb.AppendLine("**Hint:** Use `get_non_compliant_nodes` or `get_stale_nodes` to drill into problem areas, or `list_configurations` to review configuration assignments.");
+
+        return sb.ToString();
+    }
+}

--- a/src/OpenDsc.Server/Mcp/NodeTools.cs
+++ b/src/OpenDsc.Server/Mcp/NodeTools.cs
@@ -9,17 +9,24 @@ using Microsoft.EntityFrameworkCore;
 
 using ModelContextProtocol.Server;
 
+using OpenDsc.Server.Authorization;
 using OpenDsc.Server.Data;
 using OpenDsc.Server.Entities;
+using OpenDsc.Server.Services;
 
 namespace OpenDsc.Server.Mcp;
 
 [McpServerToolType]
-public sealed class NodeTools(ServerDbContext db)
+public sealed class NodeTools(ServerDbContext db, IUserContextService userContext)
 {
     [McpServerTool(Name = "get_non_compliant_nodes"), Description("Get a list of nodes that are not in compliance. Returns nodes with NonCompliant or Error status.")]
     public async Task<string> GetNonCompliantNodes(CancellationToken cancellationToken)
     {
+        if (!userContext.HasPermission(Permissions.Nodes_Read))
+        {
+            return "Access denied. You need the `nodes.read` permission.";
+        }
+
         var nodes = await db.Nodes
             .AsNoTracking()
             .Where(n => n.Status == NodeStatus.NonCompliant || n.Status == NodeStatus.Error)
@@ -54,6 +61,11 @@ public sealed class NodeTools(ServerDbContext db)
         [Description("The compliance status to filter by (Unknown, Compliant, NonCompliant, Error).")] string status,
         CancellationToken cancellationToken)
     {
+        if (!userContext.HasPermission(Permissions.Nodes_Read))
+        {
+            return "Access denied. You need the `nodes.read` permission.";
+        }
+
         if (!Enum.TryParse<NodeStatus>(status, ignoreCase: true, out var nodeStatus))
         {
             return $"Invalid status `{status}`. Valid values are: `Unknown`, `Compliant`, `NonCompliant`, `Error`.";
@@ -93,6 +105,11 @@ public sealed class NodeTools(ServerDbContext db)
         [Description("The node's fully qualified domain name or GUID identifier.")] string nodeIdentifier,
         CancellationToken cancellationToken)
     {
+        if (!userContext.HasPermission(Permissions.Nodes_Read))
+        {
+            return "Access denied. You need the `nodes.read` permission.";
+        }
+
         var settings = await db.ServerSettings.AsNoTracking().FirstOrDefaultAsync(cancellationToken);
         var staleness = settings?.StalenessMultiplier ?? 2.0;
         var now = DateTimeOffset.UtcNow;
@@ -142,16 +159,23 @@ public sealed class NodeTools(ServerDbContext db)
     [McpServerTool(Name = "get_stale_nodes"), Description("Get nodes that have not checked in within the expected interval (stale nodes). A node is stale when its last check-in exceeds ConfigurationModeInterval multiplied by the staleness multiplier.")]
     public async Task<string> GetStaleNodes(CancellationToken cancellationToken)
     {
+        if (!userContext.HasPermission(Permissions.Nodes_Read))
+        {
+            return "Access denied. You need the `nodes.read` permission.";
+        }
+
         var settings = await db.ServerSettings.AsNoTracking().FirstOrDefaultAsync(cancellationToken);
         var staleness = settings?.StalenessMultiplier ?? 2.0;
         var now = DateTimeOffset.UtcNow;
 
-        var nodes = await db.Nodes.AsNoTracking().ToListAsync(cancellationToken);
+        var candidates = await db.Nodes
+            .AsNoTracking()
+            .Where(n => n.LastCheckIn != null && n.ConfigurationModeInterval != null)
+            .Select(n => new { n.Fqdn, n.Status, n.LastCheckIn, n.ConfigurationModeInterval })
+            .ToListAsync(cancellationToken);
 
-        var staleNodes = nodes
-            .Where(n => n.LastCheckIn.HasValue
-                && n.ConfigurationModeInterval.HasValue
-                && (now - n.LastCheckIn.Value) > n.ConfigurationModeInterval.Value * staleness)
+        var staleNodes = candidates
+            .Where(n => (now - n.LastCheckIn!.Value) > n.ConfigurationModeInterval!.Value * staleness)
             .OrderBy(n => n.LastCheckIn)
             .ToList();
 
@@ -168,7 +192,7 @@ public sealed class NodeTools(ServerDbContext db)
 
         foreach (var n in staleNodes)
         {
-            sb.AppendLine($"| {n.Fqdn} | **{n.Status}** | {n.LastCheckIn?.ToString("u") ?? "never"} |");
+            sb.AppendLine($"| {n.Fqdn} | **{n.Status}** | {n.LastCheckIn!.Value.ToString("u")} |");
         }
 
         sb.AppendLine();
@@ -180,23 +204,34 @@ public sealed class NodeTools(ServerDbContext db)
     [McpServerTool(Name = "get_compliance_summary"), Description("Get an overall compliance summary showing the count of nodes in each status category. Use this as a starting point to understand the fleet's health.")]
     public async Task<string> GetComplianceSummary(CancellationToken cancellationToken)
     {
+        if (!userContext.HasPermission(Permissions.Nodes_Read))
+        {
+            return "Access denied. You need the `nodes.read` permission.";
+        }
+
         var settings = await db.ServerSettings.AsNoTracking().FirstOrDefaultAsync(cancellationToken);
         var staleness = settings?.StalenessMultiplier ?? 2.0;
         var now = DateTimeOffset.UtcNow;
 
-        var nodes = await db.Nodes.AsNoTracking().ToListAsync(cancellationToken);
-
-        var statusGroups = nodes
+        var statusGroups = await db.Nodes
+            .AsNoTracking()
             .GroupBy(n => n.Status)
-            .ToDictionary(g => g.Key, g => g.Count());
+            .Select(g => new { Status = g.Key, Count = g.Count() })
+            .ToDictionaryAsync(g => g.Status, g => g.Count, cancellationToken);
 
-        var staleCount = nodes.Count(n =>
-            n.LastCheckIn.HasValue
-            && n.ConfigurationModeInterval.HasValue
-            && (now - n.LastCheckIn.Value) > n.ConfigurationModeInterval.Value * staleness);
+        var totalNodes = statusGroups.Values.Sum();
+
+        var staleCandidates = await db.Nodes
+            .AsNoTracking()
+            .Where(n => n.LastCheckIn != null && n.ConfigurationModeInterval != null)
+            .Select(n => new { n.LastCheckIn, n.ConfigurationModeInterval })
+            .ToListAsync(cancellationToken);
+
+        var staleCount = staleCandidates.Count(n =>
+            (now - n.LastCheckIn!.Value) > n.ConfigurationModeInterval!.Value * staleness);
 
         var sb = new StringBuilder();
-        sb.AppendLine($"## Compliance Summary ({nodes.Count} total nodes)");
+        sb.AppendLine($"## Compliance Summary ({totalNodes} total nodes)");
         sb.AppendLine();
         sb.AppendLine("| Status | Count |");
         sb.AppendLine("|--------|-------|");

--- a/src/OpenDsc.Server/Mcp/ReportTools.cs
+++ b/src/OpenDsc.Server/Mcp/ReportTools.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Thomas Nieto - All Rights Reserved
+// You may use, distribute and modify this code under the
+// terms of the MIT license.
+
+using System.ComponentModel;
+using System.Text;
+
+using Microsoft.EntityFrameworkCore;
+
+using ModelContextProtocol.Server;
+
+using OpenDsc.Server.Data;
+
+namespace OpenDsc.Server.Mcp;
+
+[McpServerToolType]
+public sealed class ReportTools(ServerDbContext db)
+{
+    [McpServerTool(Name = "get_recent_reports"), Description("Get the most recent compliance reports across all nodes. Use this to see recent activity.")]
+    public async Task<string> GetRecentReports(
+        [Description("Maximum number of reports to return (default: 10, max: 50).")] int? count,
+        CancellationToken cancellationToken)
+    {
+        var take = Math.Clamp(count ?? 10, 1, 50);
+
+        var reports = await db.Reports
+            .AsNoTracking()
+            .Include(r => r.Node)
+            .OrderByDescending(r => r.Timestamp)
+            .Take(take)
+            .Select(r => new { r.Id, r.NodeId, NodeFqdn = r.Node!.Fqdn, r.Timestamp, Operation = r.Operation.ToString(), r.InDesiredState, r.HadErrors })
+            .ToListAsync(cancellationToken);
+
+        if (reports.Count == 0)
+        {
+            return "No compliance reports found.";
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"## Recent Reports ({reports.Count})");
+        sb.AppendLine();
+        sb.AppendLine("| Timestamp | Node | Operation | Compliant | Errors |");
+        sb.AppendLine("|-----------|------|-----------|-----------|--------|");
+
+        foreach (var r in reports)
+        {
+            sb.AppendLine($"| {r.Timestamp:u} | {r.NodeFqdn} | {r.Operation} | {(r.InDesiredState ? "Yes" : "**No**")} | {(r.HadErrors ? "**Yes**" : "No")} |");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("**Hint:** Use `get_node_reports` with a node's FQDN to see its full history, or `get_failed_reports` to focus on problems.");
+
+        return sb.ToString();
+    }
+
+    [McpServerTool(Name = "get_node_reports"), Description("Get compliance reports for a specific node. Use this to review a node's compliance history.")]
+    public async Task<string> GetNodeReports(
+        [Description("The node's fully qualified domain name or GUID identifier.")] string nodeIdentifier,
+        [Description("Maximum number of reports to return (default: 10, max: 50).")] int? count,
+        CancellationToken cancellationToken)
+    {
+        var take = Math.Clamp(count ?? 10, 1, 50);
+
+        IQueryable<Entities.Node> query = db.Nodes.AsNoTracking();
+
+        if (Guid.TryParse(nodeIdentifier, out var nodeId))
+        {
+            query = query.Where(n => n.Id == nodeId);
+        }
+        else
+        {
+            query = query.Where(n => n.Fqdn == nodeIdentifier);
+        }
+
+        var node = await query.FirstOrDefaultAsync(cancellationToken);
+        if (node is null)
+        {
+            return $"Node `{nodeIdentifier}` not found.";
+        }
+
+        var reports = await db.Reports
+            .AsNoTracking()
+            .Where(r => r.NodeId == node.Id)
+            .OrderByDescending(r => r.Timestamp)
+            .Take(take)
+            .Select(r => new { r.Id, r.Timestamp, Operation = r.Operation.ToString(), r.InDesiredState, r.HadErrors })
+            .ToListAsync(cancellationToken);
+
+        if (reports.Count == 0)
+        {
+            return $"No compliance reports found for node `{node.Fqdn}`.";
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"## Reports for {node.Fqdn} (showing {reports.Count})");
+        sb.AppendLine();
+        sb.AppendLine("| Timestamp | Operation | Compliant | Errors |");
+        sb.AppendLine("|-----------|-----------|-----------|--------|");
+
+        foreach (var r in reports)
+        {
+            sb.AppendLine($"| {r.Timestamp:u} | {r.Operation} | {(r.InDesiredState ? "Yes" : "**No**")} | {(r.HadErrors ? "**Yes**" : "No")} |");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("**Hint:** Use `get_node_details` with this node's FQDN for its current status and configuration info.");
+
+        return sb.ToString();
+    }
+
+    [McpServerTool(Name = "get_failed_reports"), Description("Get recent reports that had errors or were not in desired state. Use this to find compliance failures.")]
+    public async Task<string> GetFailedReports(
+        [Description("Maximum number of reports to return (default: 10, max: 50).")] int? count,
+        CancellationToken cancellationToken)
+    {
+        var take = Math.Clamp(count ?? 10, 1, 50);
+
+        var reports = await db.Reports
+            .AsNoTracking()
+            .Include(r => r.Node)
+            .Where(r => !r.InDesiredState || r.HadErrors)
+            .OrderByDescending(r => r.Timestamp)
+            .Take(take)
+            .Select(r => new { r.Id, NodeFqdn = r.Node!.Fqdn, r.Timestamp, Operation = r.Operation.ToString(), r.InDesiredState, r.HadErrors })
+            .ToListAsync(cancellationToken);
+
+        if (reports.Count == 0)
+        {
+            return "No failed or non-compliant reports found.";
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"## Failed/Non-Compliant Reports ({reports.Count})");
+        sb.AppendLine();
+        sb.AppendLine("| Timestamp | Node | Operation | Compliant | Errors |");
+        sb.AppendLine("|-----------|------|-----------|-----------|--------|");
+
+        foreach (var r in reports)
+        {
+            sb.AppendLine($"| {r.Timestamp:u} | {r.NodeFqdn} | {r.Operation} | {(r.InDesiredState ? "Yes" : "**No**")} | {(r.HadErrors ? "**Yes**" : "No")} |");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("**Hint:** Use `get_node_details` with a node's FQDN to investigate its current state.");
+
+        return sb.ToString();
+    }
+}

--- a/src/OpenDsc.Server/Mcp/ReportTools.cs
+++ b/src/OpenDsc.Server/Mcp/ReportTools.cs
@@ -9,23 +9,29 @@ using Microsoft.EntityFrameworkCore;
 
 using ModelContextProtocol.Server;
 
+using OpenDsc.Server.Authorization;
 using OpenDsc.Server.Data;
+using OpenDsc.Server.Services;
 
 namespace OpenDsc.Server.Mcp;
 
 [McpServerToolType]
-public sealed class ReportTools(ServerDbContext db)
+public sealed class ReportTools(ServerDbContext db, IUserContextService userContext)
 {
     [McpServerTool(Name = "get_recent_reports"), Description("Get the most recent compliance reports across all nodes. Use this to see recent activity.")]
     public async Task<string> GetRecentReports(
         [Description("Maximum number of reports to return (default: 10, max: 50).")] int? count,
         CancellationToken cancellationToken)
     {
+        if (!userContext.HasPermission(Permissions.Reports_ReadAll))
+        {
+            return "Access denied. You need the `reports.read-all` permission.";
+        }
+
         var take = Math.Clamp(count ?? 10, 1, 50);
 
         var reports = await db.Reports
             .AsNoTracking()
-            .Include(r => r.Node)
             .OrderByDescending(r => r.Timestamp)
             .Take(take)
             .Select(r => new { r.Id, r.NodeId, NodeFqdn = r.Node!.Fqdn, r.Timestamp, Operation = r.Operation.ToString(), r.InDesiredState, r.HadErrors })
@@ -59,6 +65,11 @@ public sealed class ReportTools(ServerDbContext db)
         [Description("Maximum number of reports to return (default: 10, max: 50).")] int? count,
         CancellationToken cancellationToken)
     {
+        if (!userContext.HasPermission(Permissions.Reports_Read))
+        {
+            return "Access denied. You need the `reports.read` permission.";
+        }
+
         var take = Math.Clamp(count ?? 10, 1, 50);
 
         IQueryable<Entities.Node> query = db.Nodes.AsNoTracking();
@@ -113,11 +124,15 @@ public sealed class ReportTools(ServerDbContext db)
         [Description("Maximum number of reports to return (default: 10, max: 50).")] int? count,
         CancellationToken cancellationToken)
     {
+        if (!userContext.HasPermission(Permissions.Reports_ReadAll))
+        {
+            return "Access denied. You need the `reports.read-all` permission.";
+        }
+
         var take = Math.Clamp(count ?? 10, 1, 50);
 
         var reports = await db.Reports
             .AsNoTracking()
-            .Include(r => r.Node)
             .Where(r => !r.InDesiredState || r.HadErrors)
             .OrderByDescending(r => r.Timestamp)
             .Take(take)

--- a/src/OpenDsc.Server/OpenDsc.Server.csproj
+++ b/src/OpenDsc.Server/OpenDsc.Server.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="Scalar.AspNetCore" />
     <PackageReference Include="YamlDotNet" />

--- a/src/OpenDsc.Server/Program.cs
+++ b/src/OpenDsc.Server/Program.cs
@@ -13,6 +13,7 @@ using OpenDsc.Server.Authentication;
 using OpenDsc.Server.Components;
 using OpenDsc.Server.Data;
 using OpenDsc.Server.Endpoints;
+using OpenDsc.Server.Mcp;
 using OpenDsc.Server.Middleware;
 using OpenDsc.Server.Services;
 
@@ -85,6 +86,14 @@ builder.Services.AddScoped<IParameterService, ParameterService>();
 builder.Services.AddScoped<IJsonYamlConverter, JsonYamlConverter>();
 builder.Services.AddSingleton<NodeEndpoints>();
 
+builder.Services
+    .AddMcpServer()
+    .WithHttpTransport(options => options.Stateless = true)
+    .WithTools<NodeTools>()
+    .WithTools<ReportTools>()
+    .WithTools<ConfigurationTools>()
+    .WithPrompts<AnalysisPrompts>();
+
 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
 {
     builder.Logging.AddSystemdConsole(options =>
@@ -133,6 +142,7 @@ app.UseAntiforgery();
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
 
+app.MapMcp();
 app.MapAuthenticationEndpoints();
 app.MapUserEndpoints();
 app.MapGroupEndpoints();

--- a/src/OpenDsc.Server/Program.cs
+++ b/src/OpenDsc.Server/Program.cs
@@ -4,6 +4,7 @@
 
 using System.Runtime.InteropServices;
 
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 
 using MudBlazor.Services;
@@ -142,7 +143,12 @@ app.UseAntiforgery();
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
 
-app.MapMcp();
+app.MapMcp("/mcp")
+    .RequireAuthorization(policy => policy
+        .RequireAuthenticatedUser()
+        .AddAuthenticationSchemes(
+            CookieAuthenticationDefaults.AuthenticationScheme,
+            PersonalAccessTokenHandler.SchemeName));
 app.MapAuthenticationEndpoints();
 app.MapUserEndpoints();
 app.MapGroupEndpoints();

--- a/src/OpenDsc.Server/Services/UserContextService.cs
+++ b/src/OpenDsc.Server/Services/UserContextService.cs
@@ -28,6 +28,13 @@ public interface IUserContextService
     /// </summary>
     /// <returns>IP address or null.</returns>
     string? GetIpAddress();
+
+    /// <summary>
+    /// Checks whether the current user has a specific permission claim.
+    /// </summary>
+    /// <param name="permission">The permission to check.</param>
+    /// <returns>True if the user has the permission, false otherwise.</returns>
+    bool HasPermission(string permission);
 }
 
 /// <summary>
@@ -52,5 +59,11 @@ public class UserContextService(IHttpContextAccessor httpContextAccessor) : IUse
     public string? GetIpAddress()
     {
         return httpContextAccessor.HttpContext?.Connection.RemoteIpAddress?.ToString();
+    }
+
+    public bool HasPermission(string permission)
+    {
+        return httpContextAccessor.HttpContext?.User
+            .HasClaim("permission", permission) ?? false;
     }
 }

--- a/tests/OpenDsc.Server.Tests/Mcp/ConfigurationToolsTests.cs
+++ b/tests/OpenDsc.Server.Tests/Mcp/ConfigurationToolsTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Thomas Nieto - All Rights Reserved
+// You may use, distribute and modify this code under the
+// terms of the MIT license.
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using OpenDsc.Lcm.Contracts;
+using OpenDsc.Server.Data;
+using OpenDsc.Server.Entities;
+using OpenDsc.Server.Mcp;
+
+using Xunit;
+
+namespace OpenDsc.Server.Tests.Mcp;
+
+[Trait("Category", "Unit")]
+public class ConfigurationToolsTests : IDisposable
+{
+    private readonly ServerDbContext _db;
+    private readonly ConfigurationTools _tools;
+
+    public ConfigurationToolsTests()
+    {
+        var options = new DbContextOptionsBuilder<ServerDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _db = new ServerDbContext(options);
+        _tools = new ConfigurationTools(_db);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task ListConfigurations_ReturnsEmpty_WhenNoneExist()
+    {
+        var result = await _tools.ListConfigurations(TestContext.Current.CancellationToken);
+
+        result.Should().Contain("No configurations found");
+    }
+
+    [Fact]
+    public async Task ListConfigurations_ReturnsConfigurations()
+    {
+        _db.Configurations.Add(new Configuration
+        {
+            Id = Guid.NewGuid(),
+            Name = "WebServer",
+            Description = "Web server config",
+            CreatedAt = DateTimeOffset.UtcNow
+        });
+        _db.Configurations.Add(new Configuration
+        {
+            Id = Guid.NewGuid(),
+            Name = "DatabaseServer",
+            CreatedAt = DateTimeOffset.UtcNow
+        });
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _tools.ListConfigurations(TestContext.Current.CancellationToken);
+
+        result.Should().Contain("Configurations (2)");
+        result.Should().Contain("WebServer");
+        result.Should().Contain("DatabaseServer");
+    }
+
+    [Fact]
+    public async Task GetConfigurationDetails_ByName_ReturnsDetails()
+    {
+        var config = new Configuration
+        {
+            Id = Guid.NewGuid(),
+            Name = "WebServer",
+            Description = "Web server configuration",
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        _db.Configurations.Add(config);
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _tools.GetConfigurationDetails("WebServer", TestContext.Current.CancellationToken);
+
+        result.Should().Contain("WebServer");
+        result.Should().Contain("Web server configuration");
+    }
+
+    [Fact]
+    public async Task GetConfigurationDetails_ReturnsNotFound_WhenNotExists()
+    {
+        var result = await _tools.GetConfigurationDetails("NonExistent", TestContext.Current.CancellationToken);
+
+        result.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task GetUnassignedNodes_ReturnsEmpty_WhenAllAssigned()
+    {
+        _db.Nodes.Add(CreateNode("web01.opendsc.dev", "WebServer"));
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _tools.GetUnassignedNodes(TestContext.Current.CancellationToken);
+
+        result.Should().Contain("All nodes have a configuration assigned");
+    }
+
+    [Fact]
+    public async Task GetUnassignedNodes_ReturnsUnassignedNodes()
+    {
+        _db.Nodes.Add(CreateNode("web01.opendsc.dev", "WebServer"));
+        _db.Nodes.Add(CreateNode("orphan.opendsc.dev", null));
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _tools.GetUnassignedNodes(TestContext.Current.CancellationToken);
+
+        result.Should().Contain("Unassigned Nodes (1)");
+        result.Should().Contain("orphan.opendsc.dev");
+        result.Should().NotContain("web01.opendsc.dev");
+    }
+
+    private static Node CreateNode(string fqdn, string? configName) => new()
+    {
+        Id = Guid.NewGuid(),
+        Fqdn = fqdn,
+        Status = NodeStatus.Unknown,
+        ConfigurationName = configName,
+        ConfigurationSource = ConfigurationSource.Pull,
+        CertificateThumbprint = "test-thumbprint",
+        CertificateSubject = "CN=test",
+        CertificateNotAfter = DateTimeOffset.UtcNow.AddYears(1),
+        CreatedAt = DateTimeOffset.UtcNow
+    };
+}

--- a/tests/OpenDsc.Server.Tests/Mcp/ConfigurationToolsTests.cs
+++ b/tests/OpenDsc.Server.Tests/Mcp/ConfigurationToolsTests.cs
@@ -6,10 +6,13 @@ using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 
+using Moq;
+
 using OpenDsc.Lcm.Contracts;
 using OpenDsc.Server.Data;
 using OpenDsc.Server.Entities;
 using OpenDsc.Server.Mcp;
+using OpenDsc.Server.Services;
 
 using Xunit;
 
@@ -18,7 +21,9 @@ namespace OpenDsc.Server.Tests.Mcp;
 [Trait("Category", "Unit")]
 public class ConfigurationToolsTests : IDisposable
 {
+    private static readonly Guid UserId = Guid.NewGuid();
     private readonly ServerDbContext _db;
+    private readonly Mock<IResourceAuthorizationService> _authService;
     private readonly ConfigurationTools _tools;
 
     public ConfigurationToolsTests()
@@ -28,7 +33,17 @@ public class ConfigurationToolsTests : IDisposable
             .Options;
 
         _db = new ServerDbContext(options);
-        _tools = new ConfigurationTools(_db);
+
+        var userContext = new Mock<IUserContextService>();
+        userContext.Setup(u => u.GetCurrentUserId()).Returns(UserId);
+        userContext.Setup(u => u.HasPermission(It.IsAny<string>())).Returns(true);
+
+        _authService = new Mock<IResourceAuthorizationService>();
+        _authService.Setup(a => a.CanReadConfigurationAsync(UserId, It.IsAny<Guid>())).ReturnsAsync(true);
+        _authService.Setup(a => a.GetReadableConfigurationIdsAsync(UserId))
+            .Returns(() => _db.Configurations.Select(c => c.Id).ToListAsync());
+
+        _tools = new ConfigurationTools(_db, userContext.Object, _authService.Object);
     }
 
     public void Dispose() => _db.Dispose();

--- a/tests/OpenDsc.Server.Tests/Mcp/NodeToolsTests.cs
+++ b/tests/OpenDsc.Server.Tests/Mcp/NodeToolsTests.cs
@@ -6,10 +6,13 @@ using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 
+using Moq;
+
 using OpenDsc.Lcm.Contracts;
 using OpenDsc.Server.Data;
 using OpenDsc.Server.Entities;
 using OpenDsc.Server.Mcp;
+using OpenDsc.Server.Services;
 
 using Xunit;
 
@@ -28,7 +31,11 @@ public class NodeToolsTests : IDisposable
             .Options;
 
         _db = new ServerDbContext(options);
-        _tools = new NodeTools(_db);
+
+        var userContext = new Mock<IUserContextService>();
+        userContext.Setup(u => u.HasPermission(It.IsAny<string>())).Returns(true);
+
+        _tools = new NodeTools(_db, userContext.Object);
     }
 
     public void Dispose() => _db.Dispose();

--- a/tests/OpenDsc.Server.Tests/Mcp/NodeToolsTests.cs
+++ b/tests/OpenDsc.Server.Tests/Mcp/NodeToolsTests.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Thomas Nieto - All Rights Reserved
+// You may use, distribute and modify this code under the
+// terms of the MIT license.
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using OpenDsc.Lcm.Contracts;
+using OpenDsc.Server.Data;
+using OpenDsc.Server.Entities;
+using OpenDsc.Server.Mcp;
+
+using Xunit;
+
+namespace OpenDsc.Server.Tests.Mcp;
+
+[Trait("Category", "Unit")]
+public class NodeToolsTests : IDisposable
+{
+    private readonly ServerDbContext _db;
+    private readonly NodeTools _tools;
+
+    public NodeToolsTests()
+    {
+        var options = new DbContextOptionsBuilder<ServerDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _db = new ServerDbContext(options);
+        _tools = new NodeTools(_db);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task GetNonCompliantNodes_ReturnsEmpty_WhenAllCompliant()
+    {
+        _db.Nodes.Add(CreateNode("node1.opendsc.dev", NodeStatus.Compliant));
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _tools.GetNonCompliantNodes(TestContext.Current.CancellationToken);
+
+        result.Should().Contain("All nodes are compliant");
+    }
+
+    [Fact]
+    public async Task GetNonCompliantNodes_ReturnsNonCompliantAndErrorNodes()
+    {
+        _db.Nodes.Add(CreateNode("good.opendsc.dev", NodeStatus.Compliant));
+        _db.Nodes.Add(CreateNode("bad.opendsc.dev", NodeStatus.NonCompliant));
+        _db.Nodes.Add(CreateNode("err.opendsc.dev", NodeStatus.Error));
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _tools.GetNonCompliantNodes(TestContext.Current.CancellationToken);
+
+        result.Should().Contain("Non-Compliant Nodes (2)");
+        result.Should().Contain("bad.opendsc.dev");
+        result.Should().Contain("err.opendsc.dev");
+        result.Should().NotContain("good.opendsc.dev");
+    }
+
+    [Fact]
+    public async Task GetNodesByStatus_ReturnsFilteredNodes()
+    {
+        _db.Nodes.Add(CreateNode("node1.opendsc.dev", NodeStatus.Compliant));
+        _db.Nodes.Add(CreateNode("node2.opendsc.dev", NodeStatus.NonCompliant));
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _tools.GetNodesByStatus("Compliant", TestContext.Current.CancellationToken);
+
+        result.Should().Contain("Nodes with Status: Compliant (1)");
+        result.Should().Contain("node1.opendsc.dev");
+    }
+
+    [Fact]
+    public async Task GetNodesByStatus_ReturnsError_ForInvalidStatus()
+    {
+        var result = await _tools.GetNodesByStatus("Invalid", TestContext.Current.CancellationToken);
+
+        result.Should().Contain("Invalid status");
+    }
+
+    [Fact]
+    public async Task GetNodeDetails_ByFqdn_ReturnsDetails()
+    {
+        _db.Nodes.Add(CreateNode("web01.opendsc.dev", NodeStatus.Compliant, "WebServer"));
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _tools.GetNodeDetails("web01.opendsc.dev", TestContext.Current.CancellationToken);
+
+        result.Should().Contain("web01.opendsc.dev");
+        result.Should().Contain("WebServer");
+        result.Should().Contain("Compliant");
+    }
+
+    [Fact]
+    public async Task GetNodeDetails_ById_ReturnsDetails()
+    {
+        var node = CreateNode("web01.opendsc.dev", NodeStatus.Compliant);
+        _db.Nodes.Add(node);
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _tools.GetNodeDetails(node.Id.ToString(), TestContext.Current.CancellationToken);
+
+        result.Should().Contain("web01.opendsc.dev");
+    }
+
+    [Fact]
+    public async Task GetNodeDetails_ReturnsNotFound_WhenNodeDoesNotExist()
+    {
+        var result = await _tools.GetNodeDetails("nonexistent.opendsc.dev", TestContext.Current.CancellationToken);
+
+        result.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task GetStaleNodes_ReturnsEmpty_WhenNoneStale()
+    {
+        var node = CreateNode("node1.opendsc.dev", NodeStatus.Compliant);
+        node.LastCheckIn = DateTimeOffset.UtcNow;
+        node.ConfigurationModeInterval = TimeSpan.FromMinutes(30);
+        _db.Nodes.Add(node);
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _tools.GetStaleNodes(TestContext.Current.CancellationToken);
+
+        result.Should().Contain("No stale nodes");
+    }
+
+    [Fact]
+    public async Task GetStaleNodes_ReturnsStaleNodes()
+    {
+        var node = CreateNode("stale.opendsc.dev", NodeStatus.Compliant);
+        node.LastCheckIn = DateTimeOffset.UtcNow.AddHours(-3);
+        node.ConfigurationModeInterval = TimeSpan.FromMinutes(30);
+        _db.Nodes.Add(node);
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _tools.GetStaleNodes(TestContext.Current.CancellationToken);
+
+        result.Should().Contain("Stale Nodes (1)");
+        result.Should().Contain("stale.opendsc.dev");
+    }
+
+    [Fact]
+    public async Task GetComplianceSummary_ReturnsCounts()
+    {
+        _db.Nodes.Add(CreateNode("c1.opendsc.dev", NodeStatus.Compliant));
+        _db.Nodes.Add(CreateNode("c2.opendsc.dev", NodeStatus.Compliant));
+        _db.Nodes.Add(CreateNode("nc.opendsc.dev", NodeStatus.NonCompliant));
+        _db.Nodes.Add(CreateNode("err.opendsc.dev", NodeStatus.Error));
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _tools.GetComplianceSummary(TestContext.Current.CancellationToken);
+
+        result.Should().Contain("4 total nodes");
+        result.Should().Contain("| Compliant | 2 |");
+        result.Should().Contain("| Non-Compliant | 1 |");
+        result.Should().Contain("| Error | 1 |");
+    }
+
+    private static Node CreateNode(string fqdn, NodeStatus status, string? configName = null) => new()
+    {
+        Id = Guid.NewGuid(),
+        Fqdn = fqdn,
+        Status = status,
+        ConfigurationName = configName,
+        ConfigurationSource = ConfigurationSource.Pull,
+        CertificateThumbprint = "test-thumbprint",
+        CertificateSubject = "CN=test",
+        CertificateNotAfter = DateTimeOffset.UtcNow.AddYears(1),
+        CreatedAt = DateTimeOffset.UtcNow
+    };
+}

--- a/tests/OpenDsc.Server.Tests/Mcp/ReportToolsTests.cs
+++ b/tests/OpenDsc.Server.Tests/Mcp/ReportToolsTests.cs
@@ -6,11 +6,14 @@ using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 
+using Moq;
+
 using OpenDsc.Lcm.Contracts;
 using OpenDsc.Schema;
 using OpenDsc.Server.Data;
 using OpenDsc.Server.Entities;
 using OpenDsc.Server.Mcp;
+using OpenDsc.Server.Services;
 
 using Xunit;
 
@@ -29,7 +32,11 @@ public class ReportToolsTests : IDisposable
             .Options;
 
         _db = new ServerDbContext(options);
-        _tools = new ReportTools(_db);
+
+        var userContext = new Mock<IUserContextService>();
+        userContext.Setup(u => u.HasPermission(It.IsAny<string>())).Returns(true);
+
+        _tools = new ReportTools(_db, userContext.Object);
     }
 
     public void Dispose() => _db.Dispose();

--- a/tests/OpenDsc.Server.Tests/Mcp/ReportToolsTests.cs
+++ b/tests/OpenDsc.Server.Tests/Mcp/ReportToolsTests.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Thomas Nieto - All Rights Reserved
+// You may use, distribute and modify this code under the
+// terms of the MIT license.
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using OpenDsc.Lcm.Contracts;
+using OpenDsc.Schema;
+using OpenDsc.Server.Data;
+using OpenDsc.Server.Entities;
+using OpenDsc.Server.Mcp;
+
+using Xunit;
+
+namespace OpenDsc.Server.Tests.Mcp;
+
+[Trait("Category", "Unit")]
+public class ReportToolsTests : IDisposable
+{
+    private readonly ServerDbContext _db;
+    private readonly ReportTools _tools;
+
+    public ReportToolsTests()
+    {
+        var options = new DbContextOptionsBuilder<ServerDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _db = new ServerDbContext(options);
+        _tools = new ReportTools(_db);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task GetRecentReports_ReturnsEmpty_WhenNoReports()
+    {
+        var result = await _tools.GetRecentReports(null, TestContext.Current.CancellationToken);
+
+        result.Should().Contain("No compliance reports found");
+    }
+
+    [Fact]
+    public async Task GetRecentReports_ReturnsReports()
+    {
+        var node = CreateNode("web01.opendsc.dev");
+        _db.Nodes.Add(node);
+        _db.Reports.Add(CreateReport(node, true, false));
+        _db.Reports.Add(CreateReport(node, false, false));
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _tools.GetRecentReports(10, TestContext.Current.CancellationToken);
+
+        result.Should().Contain("Recent Reports (2)");
+        result.Should().Contain("web01.opendsc.dev");
+    }
+
+    [Fact]
+    public async Task GetRecentReports_RespectsCount()
+    {
+        var node = CreateNode("web01.opendsc.dev");
+        _db.Nodes.Add(node);
+        for (int i = 0; i < 5; i++)
+        {
+            _db.Reports.Add(CreateReport(node, true, false));
+        }
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _tools.GetRecentReports(2, TestContext.Current.CancellationToken);
+
+        result.Should().Contain("Recent Reports (2)");
+    }
+
+    [Fact]
+    public async Task GetNodeReports_ReturnsReportsForNode()
+    {
+        var node = CreateNode("web01.opendsc.dev");
+        _db.Nodes.Add(node);
+        _db.Reports.Add(CreateReport(node, true, false));
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _tools.GetNodeReports("web01.opendsc.dev", null, TestContext.Current.CancellationToken);
+
+        result.Should().Contain("web01.opendsc.dev");
+        result.Should().Contain("showing 1");
+    }
+
+    [Fact]
+    public async Task GetNodeReports_ReturnsNotFound_WhenNodeDoesNotExist()
+    {
+        var result = await _tools.GetNodeReports("nonexistent.opendsc.dev", null, TestContext.Current.CancellationToken);
+
+        result.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task GetFailedReports_ReturnsEmpty_WhenAllCompliant()
+    {
+        var node = CreateNode("web01.opendsc.dev");
+        _db.Nodes.Add(node);
+        _db.Reports.Add(CreateReport(node, true, false));
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _tools.GetFailedReports(null, TestContext.Current.CancellationToken);
+
+        result.Should().Contain("No failed or non-compliant reports found");
+    }
+
+    [Fact]
+    public async Task GetFailedReports_ReturnsFailedReports()
+    {
+        var node = CreateNode("web01.opendsc.dev");
+        _db.Nodes.Add(node);
+        _db.Reports.Add(CreateReport(node, true, false));
+        _db.Reports.Add(CreateReport(node, false, false));
+        _db.Reports.Add(CreateReport(node, true, true));
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await _tools.GetFailedReports(null, TestContext.Current.CancellationToken);
+
+        result.Should().Contain("Failed/Non-Compliant Reports (2)");
+    }
+
+    private static Node CreateNode(string fqdn) => new()
+    {
+        Id = Guid.NewGuid(),
+        Fqdn = fqdn,
+        Status = NodeStatus.Compliant,
+        ConfigurationSource = ConfigurationSource.Pull,
+        CertificateThumbprint = "test-thumbprint",
+        CertificateSubject = "CN=test",
+        CertificateNotAfter = DateTimeOffset.UtcNow.AddYears(1),
+        CreatedAt = DateTimeOffset.UtcNow
+    };
+
+    private static Report CreateReport(Node node, bool inDesiredState, bool hadErrors) => new()
+    {
+        Id = Guid.NewGuid(),
+        NodeId = node.Id,
+        Node = node,
+        Timestamp = DateTimeOffset.UtcNow,
+        Operation = DscOperation.Test,
+        InDesiredState = inDesiredState,
+        HadErrors = hadErrors,
+        ResultJson = "{}"
+    };
+}


### PR DESCRIPTION
Added MCP support to the Pull Server, allowing AI assistants to query it directly. The current PR includes:

- Tools for checking node compliance, finding stale nodes, and viewing reports.
- Buil-in prompts for common tasks like analyzing fleet health
- OUtput formatted as Markdown tables for easy reading (and consuming LLM)

Added `SKILLS.md` and agent file for generation.