### PR TITLE
feat: add whatIf support for resource manifest

### DIFF
--- a/.github/instructions/dsc-resource.instructions.md
+++ b/.github/instructions/dsc-resource.instructions.md
@@ -50,9 +50,9 @@ All interfaces are optional — implement those that make sense. Strive to imple
 **Interface contracts:**
 - `IGettable.Get(Schema)` — return current state; set `Exist = false` if not found (never explicitly set `Exist = true`)
 - `ISettable.Set(Schema)` — apply changes; do NOT check `_exist` (DSC engine routes: `_exist=true` → `Set()`, `_exist=false` → `Delete()`)
-- `ISettableWhatIf.SetWhatIf(Schema)` — compute and return the projected state (and `ChangedProperties`) without mutating the system; declares the `whatIfArg` entry in the manifest's `set` args
+- `ISettableWhatIf.SetWhatIf(Schema?)` — compute and return the projected state (and `ChangedProperties`) without mutating the system; declares the `whatIfArg` entry in the manifest's `set` args
 - `IDeletable.Delete(Schema)` — remove resource
-- `IDeletableWhatIf.DeleteWhatIf(Schema)` — return a `DeleteResult` describing what deletion would change (via `_metadata.whatIf` messages) without mutating the system
+- `IDeletableWhatIf.DeleteWhatIf(Schema?)` — return a `DeleteResult` describing what deletion would change (via `_metadata.whatIf` messages) without mutating the system
 - `IExportable.Export(Schema? filter)` — yield all instances, optionally filtered
 
 ## GetSchema() Method

--- a/.github/instructions/dsc-resource.instructions.md
+++ b/.github/instructions/dsc-resource.instructions.md
@@ -50,7 +50,9 @@ All interfaces are optional — implement those that make sense. Strive to imple
 **Interface contracts:**
 - `IGettable.Get(Schema)` — return current state; set `Exist = false` if not found (never explicitly set `Exist = true`)
 - `ISettable.Set(Schema)` — apply changes; do NOT check `_exist` (DSC engine routes: `_exist=true` → `Set()`, `_exist=false` → `Delete()`)
+- `ISettableWhatIf.SetWhatIf(Schema)` — compute and return the projected state (and `ChangedProperties`) without mutating the system; declares the `whatIfArg` entry in the manifest's `set` args
 - `IDeletable.Delete(Schema)` — remove resource
+- `IDeletableWhatIf.DeleteWhatIf(Schema)` — return a `DeleteResult` describing what deletion would change (via `_metadata.whatIf` messages) without mutating the system
 - `IExportable.Export(Schema? filter)` — yield all instances, optionally filtered
 
 ## GetSchema() Method

--- a/.github/skills/create-dsc-resource/SKILL.md
+++ b/.github/skills/create-dsc-resource/SKILL.md
@@ -56,7 +56,7 @@ Create `src/OpenDsc.Resource.{Area}/{Name}/`:
 - [ ] `[DscResource("OpenDsc.{Area}/{Name}", "0.1.0", Description = "...", Tags = [...])]`
 - [ ] `[ExitCode]` attributes for expected exception types
 - [ ] `GetSchema()` using `SchemaRegistry.CreateBundle()` source generation pattern
-- [ ] Applicable interfaces implemented (`IGettable`, `ISettable`, `IDeletable`, `IExportable`)
+- [ ] Applicable interfaces implemented (`IGettable`, `ISettable`, `ISettableWhatIf`, `IDeletable`, `IDeletableWhatIf`, `IExportable`)
 - [ ] MIT license header
 
 **Schema.cs checklist:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+### Added
+
+- Add what-if support to the resource development kit: `ISettableWhatIf<T>` and
+  `IDeletableWhatIf<T>` interfaces, `--what-if`/`-w` options on the `set` and
+  `delete` commands, and manifest emission of the DSC v3.2.0+ `whatIfArg` and
+  `whatIfReturns` properties
+
 ## [0.5.1] - 2026-03-25
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,6 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1903</WarningsNotAsErrors>
     <JsonSchemaDefaultPropertyNaming>CamelCase</JsonSchemaDefaultPropertyNaming>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1903</WarningsNotAsErrors>
     <JsonSchemaDefaultPropertyNaming>CamelCase</JsonSchemaDefaultPropertyNaming>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.EventLog" Version="10.0.0" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.0" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageVersion Include="WixToolset.UI.wixext" Version="6.0.2" />
     <PackageVersion Include="WixToolset.Util.wixext" Version="6.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
@@ -34,9 +34,9 @@
     <PackageVersion Include="Microsoft.SqlServer.SqlManagementObjects" Version="180.10.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.0.18" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,9 +34,11 @@
     <PackageVersion Include="Microsoft.SqlServer.SqlManagementObjects" Version="180.10.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.0.18" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.EventLog" Version="10.0.0" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.0" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageVersion Include="WixToolset.UI.wixext" Version="6.0.2" />
     <PackageVersion Include="WixToolset.Util.wixext" Version="6.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
@@ -35,10 +35,8 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
-    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.0.18" />

--- a/docs/concepts/resources/index.md
+++ b/docs/concepts/resources/index.md
@@ -55,13 +55,15 @@ Some resources have a sub-area for further organization:
 
 Each resource implements one or more capability interfaces:
 
-| Capability | Operation | Description                                           |
-| :--------- | :-------- | :---------------------------------------------------- |
-| Get        | `get`     | Retrieve the current state of a resource instance     |
-| Set        | `set`     | Apply the desired state to a resource instance        |
-| Test       | `test`    | Check whether an instance matches the desired state   |
-| Delete     | `delete`  | Remove a resource instance                            |
-| Export     | `export`  | Enumerate all instances of the resource on the system |
+| Capability      | Operation           | Description                                           |
+| :-------------- | :------------------ | :---------------------------------------------------- |
+| Get             | `get`               | Retrieve the current state of a resource instance     |
+| Set             | `set`               | Apply the desired state to a resource instance        |
+| Set (what-if)   | `set --what-if`     | Preview the changes Set would make without applying   |
+| Test            | `test`              | Check whether an instance matches the desired state   |
+| Delete          | `delete`            | Remove a resource instance                            |
+| Delete (what-if)| `delete --what-if`  | Preview the changes Delete would make without applying|
+| Export          | `export`            | Enumerate all instances of the resource on the system |
 
 Not every resource implements all capabilities. Use `dsc resource list` to see
 which capabilities

--- a/docs/concepts/resources/operations.md
+++ b/docs/concepts/resources/operations.md
@@ -38,6 +38,22 @@ dsc resource set -r OpenDsc.Windows/Environment --input '{
 }'
 ```
 
+### What-if
+
+Resources that support the set what-if capability can preview the changes a Set
+operation would make without applying them. The resource manifest declares this
+by including a `whatIfArg` entry in the `set` operation's arguments; DSC then
+invokes the same set executable with that argument appended when running
+`dsc config set --what-if`. The optional `whatIfReturns` property overrides
+`return` during what-if execution.
+
+When a resource doesn't support native what-if, DSC falls back to a synthetic
+what-if based on the Test operation.
+
+```powershell
+dsc config set --file ./config.dsc.yaml --what-if
+```
+
 ## Test
 
 The **Test** operation checks whether a resource instance matches its desired
@@ -64,6 +80,11 @@ capability.
 ```powershell
 dsc resource delete -r OpenDsc.Windows/Environment --input '{"name":"DSC_EXAMPLE","scope":"User"}'
 ```
+
+Resources may also support the delete what-if capability, declared with a
+`whatIfArg` entry in the `delete` operation's arguments. In what-if mode the
+resource reports the changes deletion would apply as a `_metadata.whatIf`
+message array instead of removing the instance.
 
 ## Export
 

--- a/src/OpenDsc.Resource.CommandLine/CommandBuilder.cs
+++ b/src/OpenDsc.Resource.CommandLine/CommandBuilder.cs
@@ -118,11 +118,17 @@ public sealed class CommandBuilder
             Description = "JSON input for the desired state"
         };
 
+        var whatIfOption = new Option<bool>("--what-if", "-w")
+        {
+            Description = "Preview the changes the set operation would make without applying them"
+        };
+
         if (!IsSingleResource)
         {
             command.Options.Add(_requiredResourceOption);
         }
         command.Options.Add(inputOption);
+        command.Options.Add(whatIfOption);
 
         command.SetAction(parseResult =>
         {
@@ -130,8 +136,9 @@ public sealed class CommandBuilder
             {
                 var resourceType = parseResult.GetValue(_requiredResourceOption);
                 var input = parseResult.GetValue(inputOption);
+                var whatIf = parseResult.GetValue(whatIfOption);
                 var registration = ResolveResource(resourceType, IsSingleResource);
-                CommandExecutor.ExecuteSet(registration, input);
+                CommandExecutor.ExecuteSet(registration, input, whatIf);
             }
             catch (Exception ex)
             {
@@ -186,11 +193,17 @@ public sealed class CommandBuilder
             Description = "JSON input identifying the resource instance"
         };
 
+        var whatIfOption = new Option<bool>("--what-if", "-w")
+        {
+            Description = "Preview the changes the delete operation would make without applying them"
+        };
+
         if (!IsSingleResource)
         {
             command.Options.Add(_requiredResourceOption);
         }
         command.Options.Add(inputOption);
+        command.Options.Add(whatIfOption);
 
         command.SetAction(parseResult =>
         {
@@ -198,8 +211,9 @@ public sealed class CommandBuilder
             {
                 var resourceType = parseResult.GetValue(_requiredResourceOption);
                 var input = parseResult.GetValue(inputOption);
+                var whatIf = parseResult.GetValue(whatIfOption);
                 var registration = ResolveResource(resourceType, IsSingleResource);
-                CommandExecutor.ExecuteDelete(registration, input);
+                CommandExecutor.ExecuteDelete(registration, input, whatIf);
             }
             catch (Exception ex)
             {

--- a/src/OpenDsc.Resource.CommandLine/CommandBuilder.cs
+++ b/src/OpenDsc.Resource.CommandLine/CommandBuilder.cs
@@ -118,17 +118,24 @@ public sealed class CommandBuilder
             Description = "JSON input for the desired state"
         };
 
-        var whatIfOption = new Option<bool>("--what-if", "-w")
+        Option<bool>? whatIfOption = null;
+        if (_registry.GetAll().Any(r => r.SetWhatIfAction is not null))
         {
-            Description = "Preview the changes the set operation would make without applying them"
-        };
+            whatIfOption = new Option<bool>("--what-if", "-w")
+            {
+                Description = "Preview the changes the set operation would make without applying them"
+            };
+        }
 
         if (!IsSingleResource)
         {
             command.Options.Add(_requiredResourceOption);
         }
         command.Options.Add(inputOption);
-        command.Options.Add(whatIfOption);
+        if (whatIfOption is not null)
+        {
+            command.Options.Add(whatIfOption);
+        }
 
         command.SetAction(parseResult =>
         {
@@ -136,7 +143,7 @@ public sealed class CommandBuilder
             {
                 var resourceType = parseResult.GetValue(_requiredResourceOption);
                 var input = parseResult.GetValue(inputOption);
-                var whatIf = parseResult.GetValue(whatIfOption);
+                var whatIf = whatIfOption is not null && parseResult.GetValue(whatIfOption);
                 var registration = ResolveResource(resourceType, IsSingleResource);
                 CommandExecutor.ExecuteSet(registration, input, whatIf);
             }
@@ -193,17 +200,24 @@ public sealed class CommandBuilder
             Description = "JSON input identifying the resource instance"
         };
 
-        var whatIfOption = new Option<bool>("--what-if", "-w")
+        Option<bool>? whatIfOption = null;
+        if (_registry.GetAll().Any(r => r.DeleteWhatIfAction is not null))
         {
-            Description = "Preview the changes the delete operation would make without applying them"
-        };
+            whatIfOption = new Option<bool>("--what-if", "-w")
+            {
+                Description = "Preview the changes the delete operation would make without applying them"
+            };
+        }
 
         if (!IsSingleResource)
         {
             command.Options.Add(_requiredResourceOption);
         }
         command.Options.Add(inputOption);
-        command.Options.Add(whatIfOption);
+        if (whatIfOption is not null)
+        {
+            command.Options.Add(whatIfOption);
+        }
 
         command.SetAction(parseResult =>
         {
@@ -211,7 +225,7 @@ public sealed class CommandBuilder
             {
                 var resourceType = parseResult.GetValue(_requiredResourceOption);
                 var input = parseResult.GetValue(inputOption);
-                var whatIf = parseResult.GetValue(whatIfOption);
+                var whatIf = whatIfOption is not null && parseResult.GetValue(whatIfOption);
                 var registration = ResolveResource(resourceType, IsSingleResource);
                 CommandExecutor.ExecuteDelete(registration, input, whatIf);
             }

--- a/src/OpenDsc.Resource.CommandLine/CommandExecutor.cs
+++ b/src/OpenDsc.Resource.CommandLine/CommandExecutor.cs
@@ -19,8 +19,19 @@ internal static class CommandExecutor
         registration.GetAction(input);
     }
 
-    internal static void ExecuteSet(ResourceRegistration registration, string? input)
+    internal static void ExecuteSet(ResourceRegistration registration, string? input, bool whatIf = false)
     {
+        if (whatIf)
+        {
+            if (registration.SetWhatIfAction == null)
+            {
+                throw new NotImplementedException($"Resource '{registration.Type}' does not support set what-if capability.");
+            }
+
+            registration.SetWhatIfAction(input);
+            return;
+        }
+
         if (registration.SetAction == null)
         {
             throw new NotImplementedException($"Resource '{registration.Type}' does not support Set capability.");
@@ -39,8 +50,19 @@ internal static class CommandExecutor
         registration.TestAction(input);
     }
 
-    internal static void ExecuteDelete(ResourceRegistration registration, string? input)
+    internal static void ExecuteDelete(ResourceRegistration registration, string? input, bool whatIf = false)
     {
+        if (whatIf)
+        {
+            if (registration.DeleteWhatIfAction == null)
+            {
+                throw new NotImplementedException($"Resource '{registration.Type}' does not support delete what-if capability.");
+            }
+
+            registration.DeleteWhatIfAction(input);
+            return;
+        }
+
         if (registration.DeleteAction == null)
         {
             throw new NotImplementedException($"Resource '{registration.Type}' does not support Delete capability.");
@@ -217,12 +239,23 @@ internal static class CommandExecutor
             setReturn = char.ToLowerInvariant(setReturnStr[0]) + setReturnStr.Substring(1);
         }
 
+        string? whatIfReturn = null;
+
+        if (registration.SetWhatIfAction is not null && metadata.WhatIfReturn != SetReturn.None)
+        {
+            var whatIfReturnStr = metadata.WhatIfReturn.ToString();
+            whatIfReturn = char.ToLowerInvariant(whatIfReturnStr[0]) + whatIfReturnStr.Substring(1);
+        }
+
         var method = BuildMethod(exeName, "set", registration, isMultiResourceExe);
         return new ManifestSetMethod
         {
             Executable = method.Executable,
-            Args = method.Args,
-            Return = setReturn
+            Args = registration.SetWhatIfAction is not null
+                ? [.. method.Args!, new WhatIfArg { Arg = "--what-if" }]
+                : method.Args,
+            Return = setReturn,
+            WhatIfReturn = whatIfReturn
         };
     }
 
@@ -243,7 +276,14 @@ internal static class CommandExecutor
 
     private static ManifestMethod BuildDeleteMethod(string exeName, ResourceRegistration registration, bool isMultiResourceExe)
     {
-        return BuildMethod(exeName, "delete", registration, isMultiResourceExe);
+        var method = BuildMethod(exeName, "delete", registration, isMultiResourceExe);
+
+        if (registration.DeleteWhatIfAction is not null)
+        {
+            method.Args = [.. method.Args!, new WhatIfArg { Arg = "--what-if" }];
+        }
+
+        return method;
     }
 
     private static ManifestExportMethod BuildExportMethod(string exeName, ResourceRegistration registration, bool isMultiResourceExe)

--- a/src/OpenDsc.Resource.CommandLine/ManifestBuilder.cs
+++ b/src/OpenDsc.Resource.CommandLine/ManifestBuilder.cs
@@ -57,11 +57,22 @@ public static class ManifestBuilder
                 setReturn = char.ToLowerInvariant(setReturnStr[0]) + setReturnStr.Substring(1);
             }
 
+            var isSettableWhatIf = resource is ISettableWhatIf<TSchema>;
+            string? whatIfReturn = null;
+            if (isSettableWhatIf && dscAttr.WhatIfReturn != SetReturn.None)
+            {
+                var whatIfReturnStr = dscAttr.WhatIfReturn.ToString();
+                whatIfReturn = char.ToLowerInvariant(whatIfReturnStr[0]) + whatIfReturnStr.Substring(1);
+            }
+
             manifest.Set = new ManifestSetMethod
             {
                 Executable = fileName,
-                Args = ["config", "set", new JsonInputArg { Arg = "--input", Mandatory = false }],
-                Return = setReturn
+                Args = isSettableWhatIf
+                    ? ["config", "set", new JsonInputArg { Arg = "--input", Mandatory = false }, new WhatIfArg { Arg = "--what-if" }]
+                    : ["config", "set", new JsonInputArg { Arg = "--input", Mandatory = false }],
+                Return = setReturn,
+                WhatIfReturn = whatIfReturn
             };
         }
 
@@ -83,7 +94,9 @@ public static class ManifestBuilder
             manifest.Delete = new ManifestMethod
             {
                 Executable = fileName,
-                Args = ["config", "delete", new JsonInputArg { Arg = "--input", Mandatory = false }]
+                Args = resource is IDeletableWhatIf<TSchema>
+                    ? ["config", "delete", new JsonInputArg { Arg = "--input", Mandatory = false }, new WhatIfArg { Arg = "--what-if" }]
+                    : ["config", "delete", new JsonInputArg { Arg = "--input", Mandatory = false }]
             };
         }
 

--- a/src/OpenDsc.Resource.CommandLine/ResourceExecutor.cs
+++ b/src/OpenDsc.Resource.CommandLine/ResourceExecutor.cs
@@ -59,6 +59,32 @@ internal static class ResourceExecutor<TResource, TSchema> where TResource : IDs
         }
     }
 
+    internal static void ExecuteSetWhatIf(IDscResource<TSchema> resource, string? inputOption)
+    {
+        TSchema? instance = inputOption is not null ? resource.Parse(inputOption) : default;
+
+        if (resource is not ISettableWhatIf<TSchema> iSettableWhatIf)
+        {
+            throw new NotImplementedException("Resource does not support set what-if capability.");
+        }
+
+        var result = iSettableWhatIf.SetWhatIf(instance);
+        var dscAttr = GetDscAttribute(resource);
+        var effectiveReturn = dscAttr.WhatIfReturn != SetReturn.None ? dscAttr.WhatIfReturn : dscAttr.SetReturn;
+
+        if (effectiveReturn != SetReturn.None)
+        {
+            var json = resource.ToJson(result.ActualState);
+            Console.WriteLine(json);
+        }
+
+        if (result.ChangedProperties is not null && effectiveReturn == SetReturn.StateAndDiff)
+        {
+            var json = JsonSerializer.Serialize(result.ChangedProperties, typeof(HashSet<string>), SourceGenerationContext.Default);
+            Console.WriteLine(json);
+        }
+    }
+
     internal static void ExecuteTest(IDscResource<TSchema> resource, string? inputOption)
     {
         TSchema? instance = inputOption is not null ? resource.Parse(inputOption) : default;
@@ -91,6 +117,20 @@ internal static class ResourceExecutor<TResource, TSchema> where TResource : IDs
         }
 
         iTDeletable.Delete(instance);
+    }
+
+    internal static void ExecuteDeleteWhatIf(IDscResource<TSchema> resource, string? inputOption)
+    {
+        TSchema? instance = inputOption is not null ? resource.Parse(inputOption) : default;
+
+        if (resource is not IDeletableWhatIf<TSchema> iDeletableWhatIf)
+        {
+            throw new NotImplementedException("Resource does not support delete what-if capability.");
+        }
+
+        var result = iDeletableWhatIf.DeleteWhatIf(instance);
+        var json = JsonSerializer.Serialize(result, typeof(DeleteResult), SourceGenerationContext.Default);
+        Console.WriteLine(json);
     }
 
     internal static void ExecuteExport(IDscResource<TSchema> resource, string? inputOption)

--- a/src/OpenDsc.Resource.CommandLine/ResourceRegistration.cs
+++ b/src/OpenDsc.Resource.CommandLine/ResourceRegistration.cs
@@ -18,9 +18,13 @@ internal sealed class ResourceRegistration
 
     internal Action<string?>? SetAction { get; }
 
+    internal Action<string?>? SetWhatIfAction { get; }
+
     internal Action<string?>? TestAction { get; }
 
     internal Action<string?>? DeleteAction { get; }
+
+    internal Action<string?>? DeleteWhatIfAction { get; }
 
     internal Action<string?>? ExportAction { get; }
 
@@ -35,8 +39,10 @@ internal sealed class ResourceRegistration
         DscResourceAttribute metadata,
         Action<string?>? getAction,
         Action<string?>? setAction,
+        Action<string?>? setWhatIfAction,
         Action<string?>? testAction,
         Action<string?>? deleteAction,
+        Action<string?>? deleteWhatIfAction,
         Action<string?>? exportAction,
         Func<string>? schemaFunc,
         Func<Type, int> exitCodeResolver)
@@ -47,8 +53,10 @@ internal sealed class ResourceRegistration
         Metadata = metadata;
         GetAction = getAction;
         SetAction = setAction;
+        SetWhatIfAction = setWhatIfAction;
         TestAction = testAction;
         DeleteAction = deleteAction;
+        DeleteWhatIfAction = deleteWhatIfAction;
         ExportAction = exportAction;
         SchemaFunc = schemaFunc;
         ExitCodeResolver = exitCodeResolver;

--- a/src/OpenDsc.Resource.CommandLine/ResourceRegistry.cs
+++ b/src/OpenDsc.Resource.CommandLine/ResourceRegistry.cs
@@ -36,12 +36,20 @@ internal sealed class ResourceRegistry
             ? (string? input) => ResourceExecutor<TResource, TSchema>.ExecuteSet(resource, input)
             : null;
 
+        Action<string?>? setWhatIfAction = resource is ISettableWhatIf<TSchema>
+            ? (string? input) => ResourceExecutor<TResource, TSchema>.ExecuteSetWhatIf(resource, input)
+            : null;
+
         Action<string?>? testAction = resource is ITestable<TSchema>
             ? (string? input) => ResourceExecutor<TResource, TSchema>.ExecuteTest(resource, input)
             : null;
 
         Action<string?>? deleteAction = resource is IDeletable<TSchema>
             ? (string? input) => ResourceExecutor<TResource, TSchema>.ExecuteDelete(resource, input)
+            : null;
+
+        Action<string?>? deleteWhatIfAction = resource is IDeletableWhatIf<TSchema>
+            ? (string? input) => ResourceExecutor<TResource, TSchema>.ExecuteDeleteWhatIf(resource, input)
             : null;
 
         Action<string?>? exportAction = resource is IExportable<TSchema>
@@ -69,8 +77,10 @@ internal sealed class ResourceRegistry
             attribute,
             getAction,
             setAction,
+            setWhatIfAction,
             testAction,
             deleteAction,
+            deleteWhatIfAction,
             exportAction,
             schemaFunc,
             exitCodeResolver);

--- a/src/OpenDsc.Resource.CommandLine/SourceGenerationContext.cs
+++ b/src/OpenDsc.Resource.CommandLine/SourceGenerationContext.cs
@@ -17,6 +17,8 @@ namespace OpenDsc.Resource.CommandLine;
 [JsonSerializable(typeof(ManifestTestMethod))]
 [JsonSerializable(typeof(ManifestExportMethod))]
 [JsonSerializable(typeof(JsonInputArg))]
+[JsonSerializable(typeof(WhatIfArg))]
+[JsonSerializable(typeof(DeleteResult))]
 [JsonSerializable(typeof(HashSet<string>))]
 [JsonSerializable(typeof(MultiResourceManifest))]
 internal partial class SourceGenerationContext : JsonSerializerContext

--- a/src/OpenDsc.Resource/DeleteResult.cs
+++ b/src/OpenDsc.Resource/DeleteResult.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Thomas Nieto - All Rights Reserved
+// You may use, distribute and modify this code under the
+// terms of the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace OpenDsc.Resource;
+
+/// <summary>
+/// Represents the result of a Delete operation invoked in what-if mode.
+/// </summary>
+public sealed class DeleteResult
+{
+    /// <summary>
+    /// Gets or sets the metadata describing the changes that deletion would apply.
+    /// </summary>
+    [JsonPropertyName("_metadata")]
+    public DeleteWhatIfMetadata? Metadata { get; set; }
+}
+
+/// <summary>
+/// Represents the what-if metadata returned by a Delete operation in what-if mode.
+/// </summary>
+public sealed class DeleteWhatIfMetadata
+{
+    /// <summary>
+    /// Gets or sets the messages describing the changes that deletion would apply.
+    /// </summary>
+    [JsonPropertyName("whatIf")]
+    public string[]? WhatIf { get; set; }
+}

--- a/src/OpenDsc.Resource/DscResourceAttribute.cs
+++ b/src/OpenDsc.Resource/DscResourceAttribute.cs
@@ -70,6 +70,14 @@ public sealed partial class DscResourceAttribute : Attribute
     /// </summary>
     public TestReturn TestReturn { get; set; } = TestReturn.State;
 
+    /// <summary>
+    /// Gets or sets what the Set operation returns in what-if mode (None, State, or StateAndDiff).
+    /// Only used when the resource implements <see cref="ISettableWhatIf{T}"/>. When set to
+    /// <see cref="SetReturn.None"/>, the manifest omits "whatIfReturns" and what-if execution
+    /// falls back to <see cref="SetReturn"/>.
+    /// </summary>
+    public SetReturn WhatIfReturn { get; set; } = SetReturn.State;
+
     private SemanticVersion? _semanticVersion;
 
     /// <summary>

--- a/src/OpenDsc.Resource/DscResourceManifest.cs
+++ b/src/OpenDsc.Resource/DscResourceManifest.cs
@@ -111,6 +111,13 @@ public class ManifestSetMethod : ManifestMethod
     /// Gets or sets what information the Set operation returns ("state" or "stateAndDiff").
     /// </summary>
     public string? Return { get; set; }
+
+    /// <summary>
+    /// Gets or sets what information the Set operation returns in what-if mode ("state" or "stateAndDiff").
+    /// When specified, this overrides <see cref="Return"/> during what-if execution.
+    /// </summary>
+    [JsonPropertyName("whatIfReturns")]
+    public string? WhatIfReturn { get; set; }
 }
 
 /// <summary>
@@ -155,4 +162,17 @@ public class JsonInputArg
     /// Gets or sets whether this argument is mandatory.
     /// </summary>
     public bool? Mandatory { get; set; }
+}
+
+/// <summary>
+/// Represents a what-if argument specification in a manifest method.
+/// The argument is passed to the executable when the operation is invoked in what-if mode.
+/// </summary>
+public class WhatIfArg
+{
+    /// <summary>
+    /// Gets or sets the command-line argument passed when in what-if mode.
+    /// </summary>
+    [JsonPropertyName("whatIfArg")]
+    public string Arg { get; set; } = string.Empty;
 }

--- a/src/OpenDsc.Resource/Interfaces.cs
+++ b/src/OpenDsc.Resource/Interfaces.cs
@@ -67,10 +67,11 @@ public interface ISettableWhatIf<T> : ISettable<T>
 {
     /// <summary>
     /// Simulates applying the desired state to the resource without making actual changes.
+    /// The implementation must not mutate the system.
     /// </summary>
     /// <param name="instance">The desired state to simulate.</param>
-    /// <returns>A <see cref="SetResult{T}"/> containing what the state would be and what properties would change.</returns>
-    SetResult<T> SetWhatIf(T instance);
+    /// <returns>A <see cref="SetResult{T}"/> containing the projected state and the properties that would change.</returns>
+    SetResult<T> SetWhatIf(T? instance);
 }
 
 /// <summary>
@@ -84,6 +85,21 @@ public interface IDeletable<T> : IDscResource<T>
     /// </summary>
     /// <param name="instance">The instance containing identifying properties of the resource to delete.</param>
     void Delete(T? instance);
+}
+
+/// <summary>
+/// Defines a resource that supports simulating deletion without applying it.
+/// </summary>
+/// <typeparam name="T">The schema type that defines the resource's properties.</typeparam>
+public interface IDeletableWhatIf<T> : IDeletable<T>
+{
+    /// <summary>
+    /// Simulates deleting the resource without making actual changes.
+    /// The implementation must not mutate the system.
+    /// </summary>
+    /// <param name="instance">The instance containing identifying properties of the resource to delete.</param>
+    /// <returns>A <see cref="DeleteResult"/> describing the changes that deletion would apply.</returns>
+    DeleteResult DeleteWhatIf(T? instance);
 }
 
 /// <summary>

--- a/src/OpenDsc.Resource/README.md
+++ b/src/OpenDsc.Resource/README.md
@@ -47,8 +47,12 @@ Implement the following interfaces to add DSC operations:
 
 - `IGettable<T>`: Retrieve current configuration
 - `ISettable<T>`: Set desired configuration
+- `ISettableWhatIf<T>`: Preview the changes Set would make without applying
+  them
 - `ITestable<T>`: Test if configuration matches desired state
 - `IDeletable<T>`: Delete configuration
+- `IDeletableWhatIf<T>`: Preview the changes Delete would make without
+  applying them
 - `IExportable<T>`: Export all instances
 
 ### Attributes
@@ -78,6 +82,9 @@ The attribute supports:
 - **Tags**: Array of tags for categorization
 - **SetReturn**: Controls `Set` operation output (None, State, StateAndDiff)
 - **TestReturn**: Controls `Test` operation output (State, StateAndDiff)
+- **WhatIfReturn**: Controls `Set` output in what-if mode (defaults to State;
+  only used when the resource implements `ISettableWhatIf<T>`; None omits
+  `whatIfReturns` from the manifest so what-if falls back to `SetReturn`)
 
 ## Requirements
 

--- a/src/OpenDsc.Server/OpenDsc.Server.csproj
+++ b/src/OpenDsc.Server/OpenDsc.Server.csproj
@@ -15,9 +15,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
-    <!-- Direct references to lift vulnerable transitive dependencies (NU1903) to patched versions -->
-    <PackageReference Include="Microsoft.OpenApi" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />

--- a/src/OpenDsc.Server/OpenDsc.Server.csproj
+++ b/src/OpenDsc.Server/OpenDsc.Server.csproj
@@ -15,6 +15,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <!-- Direct references to lift vulnerable transitive dependencies (NU1903) to patched versions -->
+    <PackageReference Include="Microsoft.OpenApi" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />

--- a/tests/OpenDsc.Resource.CommandLine.IntegrationTests/TestResources.cs
+++ b/tests/OpenDsc.Resource.CommandLine.IntegrationTests/TestResources.cs
@@ -127,6 +127,81 @@ public class TestResourceGetSet : DscResource<TestSchema>,
 }
 
 /// <summary>
+/// Test resource that implements set and delete what-if capabilities.
+/// Tracks whether the non-what-if operations were invoked so tests can
+/// assert that what-if execution does not mutate anything.
+/// </summary>
+[DscResource("TestResource/WhatIf", "1.0.0", SetReturn = SetReturn.StateAndDiff, WhatIfReturn = SetReturn.StateAndDiff)]
+public class TestResourceWithWhatIf : DscResource<TestSchema>,
+    IGettable<TestSchema>,
+    ISettableWhatIf<TestSchema>,
+    IDeletableWhatIf<TestSchema>
+{
+    public bool SetInvoked { get; private set; }
+
+    public bool DeleteInvoked { get; private set; }
+
+    public TestResourceWithWhatIf() : base(new TestSourceGenerationContext())
+    {
+    }
+
+    public override string GetSchema()
+    {
+        return """
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://example.com/test-resource-whatif.json",
+            "title": "TestResourceWithWhatIf",
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "value": { "type": "string" },
+                "enabled": { "type": "boolean" }
+            }
+        }
+        """;
+    }
+
+    public TestSchema Get(TestSchema? filter)
+    {
+        return new TestSchema { Name = "test", Value = "value", Enabled = true };
+    }
+
+    public SetResult<TestSchema>? Set(TestSchema? desiredState)
+    {
+        SetInvoked = true;
+        return new SetResult<TestSchema>(desiredState ?? new TestSchema())
+        {
+            ChangedProperties = new HashSet<string> { "name" }
+        };
+    }
+
+    public SetResult<TestSchema> SetWhatIf(TestSchema? desiredState)
+    {
+        return new SetResult<TestSchema>(desiredState ?? new TestSchema())
+        {
+            ChangedProperties = new HashSet<string> { "name" }
+        };
+    }
+
+    public void Delete(TestSchema? instance)
+    {
+        DeleteInvoked = true;
+    }
+
+    public DeleteResult DeleteWhatIf(TestSchema? instance)
+    {
+        return new DeleteResult
+        {
+            Metadata = new DeleteWhatIfMetadata
+            {
+                WhatIf = [$"Would delete '{instance?.Name ?? "unknown"}'"]
+            }
+        };
+    }
+}
+
+/// <summary>
 /// Test resource with no capabilities (for error testing)
 /// </summary>
 [DscResource("TestResource/NoOps", "1.0.0")]

--- a/tests/OpenDsc.Resource.CommandLine.IntegrationTests/WhatIfExecutionTests.cs
+++ b/tests/OpenDsc.Resource.CommandLine.IntegrationTests/WhatIfExecutionTests.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Thomas Nieto - All Rights Reserved
+// You may use, distribute and modify this code under the
+// terms of the MIT license.
+
+using Xunit;
+
+namespace OpenDsc.Resource.CommandLine.IntegrationTests;
+
+/// <summary>
+/// End-to-end tests for what-if execution through the System.CommandLine pipeline.
+/// Only success paths are invoked in-process; failure paths call Environment.Exit
+/// and are covered by manifest/structure tests instead.
+/// </summary>
+[Trait("Category", "Integration")]
+public class WhatIfExecutionTests
+{
+    private static string CaptureConsoleOut(Action action)
+    {
+        var original = Console.Out;
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+        try
+        {
+            action();
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+
+        return writer.ToString();
+    }
+
+    [Fact]
+    public void SetWhatIf_PrintsProjectedStateAndDiff()
+    {
+        // Arrange
+        var resource = new TestResourceWithWhatIf();
+        var builder = new CommandBuilder();
+        builder.AddResource<TestResourceWithWhatIf, TestSchema>(resource);
+        var root = builder.Build();
+
+        // Act
+        var output = CaptureConsoleOut(() =>
+            root.Parse(["set", "--input", """{"name":"demo"}""", "--what-if"]).Invoke());
+
+        // Assert
+        var lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(2, lines.Length);
+        Assert.Contains("\"name\":\"demo\"", lines[0]);
+        Assert.Contains("name", lines[1]);
+    }
+
+    [Fact]
+    public void SetWhatIf_DoesNotInvokeSet()
+    {
+        // Arrange
+        var resource = new TestResourceWithWhatIf();
+        var builder = new CommandBuilder();
+        builder.AddResource<TestResourceWithWhatIf, TestSchema>(resource);
+        var root = builder.Build();
+
+        // Act
+        CaptureConsoleOut(() =>
+            root.Parse(["set", "--input", """{"name":"demo"}""", "--what-if"]).Invoke());
+
+        // Assert
+        Assert.False(resource.SetInvoked);
+    }
+
+    [Fact]
+    public void Set_WithoutWhatIf_InvokesSet()
+    {
+        // Arrange
+        var resource = new TestResourceWithWhatIf();
+        var builder = new CommandBuilder();
+        builder.AddResource<TestResourceWithWhatIf, TestSchema>(resource);
+        var root = builder.Build();
+
+        // Act
+        CaptureConsoleOut(() =>
+            root.Parse(["set", "--input", """{"name":"demo"}"""]).Invoke());
+
+        // Assert
+        Assert.True(resource.SetInvoked);
+    }
+
+    [Fact]
+    public void DeleteWhatIf_PrintsDeleteResult_AndDoesNotInvokeDelete()
+    {
+        // Arrange
+        var resource = new TestResourceWithWhatIf();
+        var builder = new CommandBuilder();
+        builder.AddResource<TestResourceWithWhatIf, TestSchema>(resource);
+        var root = builder.Build();
+
+        // Act
+        var output = CaptureConsoleOut(() =>
+            root.Parse(["delete", "--input", """{"name":"demo"}""", "--what-if"]).Invoke());
+
+        // Assert
+        Assert.Contains("\"_metadata\"", output);
+        Assert.Contains("\"whatIf\"", output);
+        Assert.Contains("Would delete \\u0027demo\\u0027", output);
+        Assert.False(resource.DeleteInvoked);
+    }
+
+    [Fact]
+    public void Delete_WithoutWhatIf_InvokesDelete()
+    {
+        // Arrange
+        var resource = new TestResourceWithWhatIf();
+        var builder = new CommandBuilder();
+        builder.AddResource<TestResourceWithWhatIf, TestSchema>(resource);
+        var root = builder.Build();
+
+        // Act
+        CaptureConsoleOut(() =>
+            root.Parse(["delete", "--input", """{"name":"demo"}"""]).Invoke());
+
+        // Assert
+        Assert.True(resource.DeleteInvoked);
+    }
+
+    [Fact]
+    public void SetWhatIf_MultiResourceExe_ExecutesCorrectResource()
+    {
+        // Arrange
+        var whatIfResource = new TestResourceWithWhatIf();
+        var builder = new CommandBuilder();
+        builder.AddResource<TestResourceWithWhatIf, TestSchema>(whatIfResource);
+        builder.AddResource<TestResourceAll, TestSchema>(new TestResourceAll());
+        var root = builder.Build();
+
+        // Act
+        var output = CaptureConsoleOut(() =>
+            root.Parse(["set", "--resource", "TestResource/WhatIf", "--input", """{"name":"demo"}""", "--what-if"]).Invoke());
+
+        // Assert
+        Assert.Contains("\"name\":\"demo\"", output);
+        Assert.False(whatIfResource.SetInvoked);
+    }
+
+    [Fact]
+    public void Manifest_WhatIfResource_EmitsWhatIfArgAndReturns()
+    {
+        // Arrange
+        var builder = new CommandBuilder();
+        builder.AddResource<TestResourceWithWhatIf, TestSchema>(new TestResourceWithWhatIf());
+        var root = builder.Build();
+
+        // Act
+        var output = CaptureConsoleOut(() => root.Parse(["manifest"]).Invoke());
+
+        // Assert
+        Assert.Contains("\"whatIfArg\":\"--what-if\"", output);
+        Assert.Contains("\"whatIfReturns\":\"stateAndDiff\"", output);
+    }
+
+    [Fact]
+    public void Manifest_NonWhatIfResource_OmitsWhatIfArtifacts()
+    {
+        // Arrange
+        var builder = new CommandBuilder();
+        builder.AddResource<TestResourceAll, TestSchema>(new TestResourceAll());
+        var root = builder.Build();
+
+        // Act
+        var output = CaptureConsoleOut(() => root.Parse(["manifest"]).Invoke());
+
+        // Assert
+        Assert.DoesNotContain("whatIfArg", output);
+        Assert.DoesNotContain("whatIfReturns", output);
+    }
+}

--- a/tests/OpenDsc.Resource.CommandLine.Tests/TestResources.cs
+++ b/tests/OpenDsc.Resource.CommandLine.Tests/TestResources.cs
@@ -127,6 +127,126 @@ public class TestResourceGetSet : DscResource<TestSchema>,
 }
 
 /// <summary>
+/// Test resource that implements set and delete what-if capabilities
+/// </summary>
+[DscResource("TestResource/WhatIf", "1.0.0", SetReturn = SetReturn.StateAndDiff, WhatIfReturn = SetReturn.StateAndDiff)]
+public class TestResourceWithWhatIf : DscResource<TestSchema>,
+    IGettable<TestSchema>,
+    ISettableWhatIf<TestSchema>,
+    ITestable<TestSchema>,
+    IDeletableWhatIf<TestSchema>
+{
+    public TestResourceWithWhatIf() : base(new TestSourceGenerationContext())
+    {
+    }
+
+    public override string GetSchema()
+    {
+        return """
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://example.com/test-resource-whatif.json",
+            "title": "TestResourceWithWhatIf",
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "value": { "type": "string" },
+                "enabled": { "type": "boolean" }
+            }
+        }
+        """;
+    }
+
+    public TestSchema Get(TestSchema? filter)
+    {
+        return new TestSchema { Name = "test", Value = "value", Enabled = true };
+    }
+
+    public SetResult<TestSchema>? Set(TestSchema? desiredState)
+    {
+        return new SetResult<TestSchema>(desiredState ?? new TestSchema())
+        {
+            ChangedProperties = new HashSet<string> { "name" }
+        };
+    }
+
+    public SetResult<TestSchema> SetWhatIf(TestSchema? desiredState)
+    {
+        return new SetResult<TestSchema>(desiredState ?? new TestSchema())
+        {
+            ChangedProperties = new HashSet<string> { "name" }
+        };
+    }
+
+    public TestResult<TestSchema> Test(TestSchema? desiredState)
+    {
+        return new TestResult<TestSchema>(desiredState ?? new TestSchema())
+        {
+            DifferingProperties = new HashSet<string>()
+        };
+    }
+
+    public void Delete(TestSchema? instance)
+    {
+        // Intentionally left empty for testing
+    }
+
+    public DeleteResult DeleteWhatIf(TestSchema? instance)
+    {
+        return new DeleteResult
+        {
+            Metadata = new DeleteWhatIfMetadata
+            {
+                WhatIf = [$"Would delete '{instance?.Name ?? "unknown"}'"]
+            }
+        };
+    }
+}
+
+/// <summary>
+/// Test resource with what-if support where WhatIfReturn is None (falls back to SetReturn)
+/// </summary>
+[DscResource("TestResource/WhatIfNoReturn", "1.0.0", SetReturn = SetReturn.State, WhatIfReturn = SetReturn.None)]
+public class TestResourceWhatIfNoReturn : DscResource<TestSchema>,
+    IGettable<TestSchema>,
+    ISettableWhatIf<TestSchema>
+{
+    public TestResourceWhatIfNoReturn() : base(new TestSourceGenerationContext())
+    {
+    }
+
+    public override string GetSchema()
+    {
+        return """
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://example.com/test-resource-whatif-noreturn.json",
+            "title": "TestResourceWhatIfNoReturn",
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" }
+            }
+        }
+        """;
+    }
+
+    public TestSchema Get(TestSchema? filter)
+    {
+        return new TestSchema { Name = "test" };
+    }
+
+    public SetResult<TestSchema>? Set(TestSchema? desiredState)
+    {
+        return new SetResult<TestSchema>(desiredState ?? new TestSchema());
+    }
+
+    public SetResult<TestSchema> SetWhatIf(TestSchema? desiredState)
+    {
+        return new SetResult<TestSchema>(desiredState ?? new TestSchema());
+    }
+}
+
+/// <summary>
 /// Test resource with no capabilities (for error testing)
 /// </summary>
 [DscResource("TestResource/NoOps", "1.0.0")]

--- a/tests/OpenDsc.Resource.CommandLine.Tests/WhatIfTests.cs
+++ b/tests/OpenDsc.Resource.CommandLine.Tests/WhatIfTests.cs
@@ -1,0 +1,229 @@
+// Copyright (c) Thomas Nieto - All Rights Reserved
+// You may use, distribute and modify this code under the
+// terms of the MIT license.
+
+using System.Text.Json;
+
+using Xunit;
+
+namespace OpenDsc.Resource.CommandLine.Tests;
+
+[Trait("Category", "Unit")]
+public class WhatIfManifestTests
+{
+    private static readonly JsonSerializerOptions IgnoreNullOptions = new()
+    {
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+    };
+
+    [Fact]
+    public void GenerateManifest_WhatIfResource_SetArgsContainWhatIfArg()
+    {
+        // Arrange
+        var resource = new TestResourceWithWhatIf();
+
+        // Act
+        var manifest = ManifestBuilder.Build(resource);
+
+        // Assert
+        Assert.NotNull(manifest.Set);
+        Assert.NotNull(manifest.Set.Args);
+        var whatIfArg = Assert.Single(manifest.Set.Args.OfType<WhatIfArg>());
+        Assert.Equal("--what-if", whatIfArg.Arg);
+    }
+
+    [Fact]
+    public void GenerateManifest_WhatIfResource_SetHasWhatIfReturn()
+    {
+        // Arrange
+        var resource = new TestResourceWithWhatIf();
+
+        // Act
+        var manifest = ManifestBuilder.Build(resource);
+
+        // Assert
+        Assert.NotNull(manifest.Set);
+        Assert.Equal("stateAndDiff", manifest.Set.WhatIfReturn);
+    }
+
+    [Fact]
+    public void GenerateManifest_WhatIfResource_WhatIfArgIsLastSetArg()
+    {
+        // Arrange
+        var resource = new TestResourceWithWhatIf();
+
+        // Act
+        var manifest = ManifestBuilder.Build(resource);
+
+        // Assert
+        Assert.NotNull(manifest.Set);
+        Assert.NotNull(manifest.Set.Args);
+        Assert.IsType<WhatIfArg>(manifest.Set.Args[^1]);
+    }
+
+    [Fact]
+    public void GenerateManifest_DeleteWhatIfResource_DeleteArgsContainWhatIfArg()
+    {
+        // Arrange
+        var resource = new TestResourceWithWhatIf();
+
+        // Act
+        var manifest = ManifestBuilder.Build(resource);
+
+        // Assert
+        Assert.NotNull(manifest.Delete);
+        Assert.NotNull(manifest.Delete.Args);
+        var whatIfArg = Assert.Single(manifest.Delete.Args.OfType<WhatIfArg>());
+        Assert.Equal("--what-if", whatIfArg.Arg);
+    }
+
+    [Fact]
+    public void GenerateManifest_WhatIfReturnNone_OmitsWhatIfReturn()
+    {
+        // Arrange
+        var resource = new TestResourceWhatIfNoReturn();
+
+        // Act
+        var manifest = ManifestBuilder.Build(resource);
+
+        // Assert
+        Assert.NotNull(manifest.Set);
+        Assert.NotNull(manifest.Set.Args);
+        Assert.Single(manifest.Set.Args.OfType<WhatIfArg>());
+        Assert.Null(manifest.Set.WhatIfReturn);
+    }
+
+    [Fact]
+    public void GenerateManifest_NonWhatIfResource_HasNoWhatIfArtifacts()
+    {
+        // Arrange
+        var resource = new TestResourceAll();
+
+        // Act
+        var manifest = ManifestBuilder.Build(resource);
+
+        // Assert
+        Assert.NotNull(manifest.Set);
+        Assert.NotNull(manifest.Set.Args);
+        Assert.Empty(manifest.Set.Args.OfType<WhatIfArg>());
+        Assert.Null(manifest.Set.WhatIfReturn);
+        Assert.NotNull(manifest.Delete);
+        Assert.NotNull(manifest.Delete.Args);
+        Assert.Empty(manifest.Delete.Args.OfType<WhatIfArg>());
+    }
+
+    [Fact]
+    public void GenerateManifest_WhatIfResource_SerializesWhatIfArgAndReturns()
+    {
+        // Arrange
+        var resource = new TestResourceWithWhatIf();
+        var manifest = ManifestBuilder.Build(resource);
+
+        // Act
+        var json = JsonSerializer.Serialize(manifest);
+
+        // Assert
+        Assert.Contains("\"whatIfArg\":\"--what-if\"", json);
+        Assert.Contains("\"whatIfReturns\":\"stateAndDiff\"", json);
+    }
+
+    [Fact]
+    public void GenerateManifest_NonWhatIfResource_SerializationOmitsWhatIf()
+    {
+        // Arrange
+        var resource = new TestResourceAll();
+        var manifest = ManifestBuilder.Build(resource);
+
+        // Act
+        // Match the production serialization contract, which omits null properties.
+        var json = JsonSerializer.Serialize(manifest, IgnoreNullOptions);
+
+        // Assert
+        Assert.DoesNotContain("whatIfArg", json);
+        Assert.DoesNotContain("whatIfReturns", json);
+    }
+}
+
+[Trait("Category", "Unit")]
+public class WhatIfCommandTests
+{
+    [Fact]
+    public void SetCommand_HasWhatIfOption()
+    {
+        // Arrange
+        var builder = new CommandBuilder();
+        builder.AddResource<TestResourceWithWhatIf, TestSchema>(new TestResourceWithWhatIf());
+
+        // Act
+        var root = builder.Build();
+        var setCommand = root.Subcommands.First(c => c.Name == "set");
+
+        // Assert
+        var whatIfOption = setCommand.Options.FirstOrDefault(o => o.Name == "--what-if");
+        Assert.NotNull(whatIfOption);
+        Assert.Contains("-w", whatIfOption.Aliases);
+    }
+
+    [Fact]
+    public void DeleteCommand_HasWhatIfOption()
+    {
+        // Arrange
+        var builder = new CommandBuilder();
+        builder.AddResource<TestResourceWithWhatIf, TestSchema>(new TestResourceWithWhatIf());
+
+        // Act
+        var root = builder.Build();
+        var deleteCommand = root.Subcommands.First(c => c.Name == "delete");
+
+        // Assert
+        var whatIfOption = deleteCommand.Options.FirstOrDefault(o => o.Name == "--what-if");
+        Assert.NotNull(whatIfOption);
+        Assert.Contains("-w", whatIfOption.Aliases);
+    }
+
+    [Fact]
+    public void SetCommand_ParsesWhatIfOption()
+    {
+        // Arrange
+        var builder = new CommandBuilder();
+        builder.AddResource<TestResourceWithWhatIf, TestSchema>(new TestResourceWithWhatIf());
+        var root = builder.Build();
+
+        // Act
+        var parseResult = root.Parse(["set", "--input", """{"name":"test"}""", "--what-if"]);
+
+        // Assert
+        Assert.Empty(parseResult.Errors);
+    }
+
+    [Fact]
+    public void SetCommand_ParsesShortWhatIfAlias()
+    {
+        // Arrange
+        var builder = new CommandBuilder();
+        builder.AddResource<TestResourceWithWhatIf, TestSchema>(new TestResourceWithWhatIf());
+        var root = builder.Build();
+
+        // Act
+        var parseResult = root.Parse(["set", "-i", """{"name":"test"}""", "-w"]);
+
+        // Assert
+        Assert.Empty(parseResult.Errors);
+    }
+
+    [Fact]
+    public void DeleteCommand_ParsesWhatIfOption_MultiResource()
+    {
+        // Arrange
+        var builder = new CommandBuilder();
+        builder.AddResource<TestResourceWithWhatIf, TestSchema>(new TestResourceWithWhatIf());
+        builder.AddResource<TestResourceAll, TestSchema>(new TestResourceAll());
+        var root = builder.Build();
+
+        // Act
+        var parseResult = root.Parse(["delete", "--resource", "TestResource/WhatIf", "--input", """{"name":"test"}""", "--what-if"]);
+
+        // Assert
+        Assert.Empty(parseResult.Errors);
+    }
+}

--- a/tests/OpenDsc.Resource.CommandLine.Tests/WhatIfTests.cs
+++ b/tests/OpenDsc.Resource.CommandLine.Tests/WhatIfTests.cs
@@ -226,4 +226,65 @@ public class WhatIfCommandTests
         // Assert
         Assert.Empty(parseResult.Errors);
     }
+
+    [Fact]
+    public void SetCommand_NonWhatIfResource_HasNoWhatIfOption()
+    {
+        // Arrange
+        var builder = new CommandBuilder();
+        builder.AddResource<TestResourceAll, TestSchema>(new TestResourceAll());
+
+        // Act
+        var root = builder.Build();
+        var setCommand = root.Subcommands.First(c => c.Name == "set");
+
+        // Assert
+        Assert.DoesNotContain(setCommand.Options, o => o.Name == "--what-if");
+    }
+
+    [Fact]
+    public void DeleteCommand_NonWhatIfResource_HasNoWhatIfOption()
+    {
+        // Arrange
+        var builder = new CommandBuilder();
+        builder.AddResource<TestResourceAll, TestSchema>(new TestResourceAll());
+
+        // Act
+        var root = builder.Build();
+        var deleteCommand = root.Subcommands.First(c => c.Name == "delete");
+
+        // Assert
+        Assert.DoesNotContain(deleteCommand.Options, o => o.Name == "--what-if");
+    }
+
+    [Fact]
+    public void SetCommand_NonWhatIfResource_WhatIfArgumentProducesParseError()
+    {
+        // Arrange
+        var builder = new CommandBuilder();
+        builder.AddResource<TestResourceAll, TestSchema>(new TestResourceAll());
+        var root = builder.Build();
+
+        // Act
+        var parseResult = root.Parse(["set", "--input", """{"name":"test"}""", "--what-if"]);
+
+        // Assert
+        Assert.NotEmpty(parseResult.Errors);
+    }
+
+    [Fact]
+    public void SetCommand_MixedResources_HasWhatIfOption()
+    {
+        // Arrange
+        var builder = new CommandBuilder();
+        builder.AddResource<TestResourceWithWhatIf, TestSchema>(new TestResourceWithWhatIf());
+        builder.AddResource<TestResourceAll, TestSchema>(new TestResourceAll());
+
+        // Act
+        var root = builder.Build();
+        var setCommand = root.Subcommands.First(c => c.Name == "set");
+
+        // Assert
+        Assert.Contains(setCommand.Options, o => o.Name == "--what-if");
+    }
 }

--- a/tests/OpenDsc.Resource.Tests/DscResourceAttributeTests.cs
+++ b/tests/OpenDsc.Resource.Tests/DscResourceAttributeTests.cs
@@ -44,6 +44,25 @@ public class DscResourceAttributeTests
     }
 
     [Fact]
+    public void DefaultValues_WhatIfReturnIsState()
+    {
+        var attr = new DscResourceAttribute("OpenDsc.Test/Resource");
+
+        attr.WhatIfReturn.Should().Be(SetReturn.State);
+    }
+
+    [Fact]
+    public void WhatIfReturn_CanBeSetToStateAndDiff()
+    {
+        var attr = new DscResourceAttribute("OpenDsc.Test/Resource")
+        {
+            WhatIfReturn = SetReturn.StateAndDiff
+        };
+
+        attr.WhatIfReturn.Should().Be(SetReturn.StateAndDiff);
+    }
+
+    [Fact]
     public void DefaultValues_DescriptionIsEmpty()
     {
         var attr = new DscResourceAttribute("OpenDsc.Test/Resource");

--- a/tests/OpenDsc.Resource.Tests/DscResourceManifestTests.cs
+++ b/tests/OpenDsc.Resource.Tests/DscResourceManifestTests.cs
@@ -197,6 +197,32 @@ public class ManifestSetMethodTests
     }
 
     [Fact]
+    public void WhatIfReturn_DefaultsToNull()
+    {
+        var method = new ManifestSetMethod();
+
+        method.WhatIfReturn.Should().BeNull();
+    }
+
+    [Fact]
+    public void WhatIfReturn_CanBeSetToState()
+    {
+        var method = new ManifestSetMethod { WhatIfReturn = "state" };
+
+        method.WhatIfReturn.Should().Be("state");
+    }
+
+    [Fact]
+    public void WhatIfReturn_SerializesAsWhatIfReturns()
+    {
+        var method = new ManifestSetMethod { Executable = "test.exe", WhatIfReturn = "state" };
+
+        var json = JsonSerializer.Serialize(method);
+
+        json.Should().Contain("\"whatIfReturns\":\"state\"");
+    }
+
+    [Fact]
     public void Return_CanBeSetToState()
     {
         var method = new ManifestSetMethod { Return = "state" };
@@ -253,6 +279,71 @@ public class ManifestTestMethodTests
         var method = new ManifestTestMethod { Executable = "test.exe" };
 
         method.Executable.Should().Be("test.exe");
+    }
+}
+
+public class WhatIfArgTests
+{
+    [Fact]
+    public void Arg_DefaultsToEmpty()
+    {
+        var arg = new WhatIfArg();
+
+        arg.Arg.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Arg_CanBeSet()
+    {
+        var arg = new WhatIfArg { Arg = "--what-if" };
+
+        arg.Arg.Should().Be("--what-if");
+    }
+
+    [Fact]
+    public void Arg_SerializesAsWhatIfArg()
+    {
+        var arg = new WhatIfArg { Arg = "--what-if" };
+
+        var json = JsonSerializer.Serialize(arg);
+
+        json.Should().Be("""{"whatIfArg":"--what-if"}""");
+    }
+}
+
+public class DeleteResultTests
+{
+    [Fact]
+    public void Metadata_DefaultsToNull()
+    {
+        var result = new DeleteResult();
+
+        result.Metadata.Should().BeNull();
+    }
+
+    [Fact]
+    public void Metadata_SerializesWithUnderscorePrefix()
+    {
+        var result = new DeleteResult
+        {
+            Metadata = new DeleteWhatIfMetadata { WhatIf = ["Would delete item"] }
+        };
+
+        var json = JsonSerializer.Serialize(result);
+
+        json.Should().Be("""{"_metadata":{"whatIf":["Would delete item"]}}""");
+    }
+
+    [Fact]
+    public void RoundTrips_ThroughJson()
+    {
+        var json = """{"_metadata":{"whatIf":["message"]}}""";
+
+        var result = JsonSerializer.Deserialize<DeleteResult>(json);
+
+        result.Should().NotBeNull();
+        result!.Metadata.Should().NotBeNull();
+        result.Metadata!.WhatIf.Should().Equal("message");
     }
 }
 

--- a/tests/TestResource.Aot/Resource.cs
+++ b/tests/TestResource.Aot/Resource.cs
@@ -9,14 +9,14 @@ using OpenDsc.Resource;
 
 namespace TestResource.Aot;
 
-[DscResource("OpenDsc.Test/AotFile", Description = "AOT test resource for file existence.", Tags = ["test", "file", "aot"], SetReturn = SetReturn.StateAndDiff, TestReturn = TestReturn.StateAndDiff)]
+[DscResource("OpenDsc.Test/AotFile", Description = "AOT test resource for file existence.", Tags = ["test", "file", "aot"], SetReturn = SetReturn.StateAndDiff, TestReturn = TestReturn.StateAndDiff, WhatIfReturn = SetReturn.StateAndDiff)]
 [ExitCode(0, Description = "Success")]
 [ExitCode(1, Exception = typeof(Exception), Description = "Error")]
 [ExitCode(2, Exception = typeof(JsonException), Description = "Invalid JSON")]
 [ExitCode(3, Exception = typeof(IOException), Description = "I/O error")]
 [ExitCode(4, Exception = typeof(DirectoryNotFoundException), Description = "Directory not found")]
 [ExitCode(5, Exception = typeof(UnauthorizedAccessException), Description = "Access denied")]
-public sealed class Resource(JsonSerializerContext context) : DscResource<Schema>(context), IGettable<Schema>, ISettable<Schema>, IDeletable<Schema>, ITestable<Schema>, IExportable<Schema>
+public sealed class Resource(JsonSerializerContext context) : DscResource<Schema>(context), IGettable<Schema>, ISettableWhatIf<Schema>, IDeletableWhatIf<Schema>, ITestable<Schema>, IExportable<Schema>
 {
     public override string GetSchema()
     {
@@ -101,6 +101,31 @@ public sealed class Resource(JsonSerializerContext context) : DscResource<Schema
         return result;
     }
 
+    public SetResult<Schema> SetWhatIf(Schema? instance)
+    {
+        ArgumentNullException.ThrowIfNull(instance);
+
+        var desiredExist = instance.Exist ?? true;
+        var currentState = Get(instance);
+        var currentExist = currentState.Exist ?? true;
+
+        if (desiredExist == currentExist)
+        {
+            return new SetResult<Schema>(currentState) { ChangedProperties = [] };
+        }
+
+        var projectedState = new Schema
+        {
+            Path = instance.Path,
+            Exist = desiredExist ? null : false
+        };
+
+        return new SetResult<Schema>(projectedState)
+        {
+            ChangedProperties = ["_exist"]
+        };
+    }
+
     public void Delete(Schema? instance)
     {
         ArgumentNullException.ThrowIfNull(instance);
@@ -109,6 +134,20 @@ public sealed class Resource(JsonSerializerContext context) : DscResource<Schema
         {
             File.Delete(instance.Path);
         }
+    }
+
+    public DeleteResult DeleteWhatIf(Schema? instance)
+    {
+        ArgumentNullException.ThrowIfNull(instance);
+
+        var messages = File.Exists(instance.Path)
+            ? new[] { $"Would delete file '{instance.Path}'" }
+            : [];
+
+        return new DeleteResult
+        {
+            Metadata = new DeleteWhatIfMetadata { WhatIf = messages }
+        };
     }
 
     public TestResult<Schema> Test(Schema? instance)

--- a/tests/TestResource.Multi/FileResource.cs
+++ b/tests/TestResource.Multi/FileResource.cs
@@ -16,14 +16,14 @@ public sealed class FileSchema
     public bool? Exist { get; set; }
 }
 
-[DscResource("TestResource.Multi/File", "1.0.0", Description = "Manages file content", Tags = ["file", "content"], SetReturn = SetReturn.State, TestReturn = TestReturn.State)]
+[DscResource("TestResource.Multi/File", "1.0.0", Description = "Manages file content", Tags = ["file", "content"], SetReturn = SetReturn.State, TestReturn = TestReturn.State, WhatIfReturn = SetReturn.State)]
 [ExitCode(0, Description = "Success")]
 [ExitCode(1, Exception = typeof(Exception), Description = "Error")]
 [ExitCode(2, Exception = typeof(IOException), Description = "I/O error")]
 [ExitCode(3, Exception = typeof(DirectoryNotFoundException), Description = "Directory not found")]
 [ExitCode(4, Exception = typeof(UnauthorizedAccessException), Description = "Access denied")]
 public sealed class FileResource(JsonSerializerContext context) : DscResource<FileSchema>(context),
-    IGettable<FileSchema>, ISettable<FileSchema>, ITestable<FileSchema>, IDeletable<FileSchema>
+    IGettable<FileSchema>, ISettableWhatIf<FileSchema>, ITestable<FileSchema>, IDeletable<FileSchema>
 {
     public FileSchema Get(FileSchema? instance)
     {
@@ -88,6 +88,42 @@ public sealed class FileResource(JsonSerializerContext context) : DscResource<Fi
 
         var actualState = Get(instance);
         return new SetResult<FileSchema>(actualState)
+        {
+            ChangedProperties = changedProperties.Count > 0 ? [.. changedProperties] : null
+        };
+    }
+
+    public SetResult<FileSchema> SetWhatIf(FileSchema? instance)
+    {
+        ArgumentNullException.ThrowIfNull(instance);
+
+        var current = Get(instance);
+        var changedProperties = new List<string>();
+
+        if (instance.Exist == false)
+        {
+            if (File.Exists(instance.Path))
+            {
+                changedProperties.Add(nameof(FileSchema.Exist));
+            }
+        }
+        else if (!File.Exists(instance.Path) || current.Content != instance.Content)
+        {
+            changedProperties.Add(nameof(FileSchema.Content));
+            if (current.Exist != true)
+            {
+                changedProperties.Add(nameof(FileSchema.Exist));
+            }
+        }
+
+        var projectedState = new FileSchema
+        {
+            Path = instance.Path,
+            Content = instance.Exist == false ? null : instance.Content,
+            Exist = instance.Exist == false ? false : null
+        };
+
+        return new SetResult<FileSchema>(projectedState)
         {
             ChangedProperties = changedProperties.Count > 0 ? [.. changedProperties] : null
         };


### PR DESCRIPTION
## Summary

This PR adds support for the DSC v3.2.0+ what-if model, where a resource
previews changes through its own `set`/`delete` operation instead of the
deprecated top-level `whatIf` manifest method.

What-if is **opt-in**. Existing resources are unaffected. Their manifests are unchanged, and DSC keeps giving users a synthetic what-if based on the `test` operation.

## For resource authors

To support native what-if, implement the new interfaces:

- `ISettableWhatIf<T>` — add `SetWhatIf(T? instance)`: return the projected
  state (and changed properties) **without changing the system**.
- `IDeletableWhatIf<T>` — add `DeleteWhatIf(T? instance)`: return a
  `DeleteResult` describing what deletion would change.

That's all. The RDK takes care of the rest:

- The generated manifest declares what-if support (`whatIfArg` in the
  operation's args, plus `whatIfReturns`).
- The resource executable gets a `--what-if`/`-w` flag on `set` and `delete`
  that routes to your what-if methods.
- The optional `WhatIfReturn` attribute property controls what-if output
  (defaults to `State`).

Implement it when a synthetic test-based preview isn't good enough. For example, when `set` computes values at apply time, applies changes partially, or when you want to return human-readable change messages.

## Notes

Fixes #16.